### PR TITLE
[User] Handle is a createOnly property

### DIFF
--- a/datadog-iam-user-handler/datadog-iam-user.json
+++ b/datadog-iam-user-handler/datadog-iam-user.json
@@ -47,6 +47,9 @@
             "type": "boolean"
         }
     },
+    "createOnlyProperties": [
+        "/properties/Handle"
+    ],
     "primaryIdentifier": [
         "/properties/Handle"
     ],


### PR DESCRIPTION
As User's Handle cannot be updated once the user is created, make it a createOnly property.