### PR TITLE
Fix minor issues in monitor schema

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -79,8 +79,8 @@
                 "No Data",
                 "OK",
                 "Skipped",
-                "Unknown"
-                "Warn",
+                "Unknown",
+                "Warn"
             ]
         },
         "MonitorState": {
@@ -284,7 +284,7 @@
         }
     },
     "required": [
-        "/properties/DatadogCredentials"
+        "DatadogCredentials"
     ],
     "writeOnlyProperties": [
         "/properties/DatadogCredentials"


### PR DESCRIPTION
`Required` shouldn't be prefixed with `/properties` like the other attributes. 
Added missing command in enum which caused validation issues. 