### PR TITLE
[Monitor] Change casing of ID field

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -223,7 +223,7 @@
         "Creator":{
             "$ref": "#/definitions/Creator"
         },
-        "ID":{
+        "Id":{
             "description": "ID of the monitor",
             "type": "number"
         },
@@ -290,11 +290,11 @@
         "/properties/DatadogCredentials"
     ],
     "primaryIdentifier": [
-        "/properties/ID"
+        "/properties/Id"
     ],
     "readOnlyProperties": [
         "/properties/Modified",
-        "/properties/ID",
+        "/properties/Id",
         "/properties/Deleted",
         "/properties/State",
         "/properties/OverallState",

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/CreateHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/CreateHandler.java
@@ -32,7 +32,6 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.getDatadogCredentials().getApiKey(),
             model.getDatadogCredentials().getApplicationKey()
         );
-
         MonitorOptions options = null;
         if (model.getOptions() != null) {
             options = new MonitorOptions()
@@ -116,8 +115,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         }
 
         // Set ID of the returned monitor, so that the read handler can request it
-        model.setID(createdMonitor.getId().doubleValue());
-
+        model.setId(createdMonitor.getId().doubleValue());
         return new ReadHandler().handleRequest(proxy, request, callbackContext, logger);
     }
 }

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/DeleteHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/DeleteHandler.java
@@ -30,7 +30,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         MonitorsApi monitorsApi = new MonitorsApi(apiClient);
 
         try {
-            monitorsApi.deleteMonitor(model.getID().longValue());
+            monitorsApi.deleteMonitor(model.getId().longValue());
         } catch (ApiException e) {
             String err = "Failed to delete monitor: " + e.toString();
             logger.log(err);

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/ReadHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/ReadHandler.java
@@ -36,7 +36,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
 
         Monitor monitor = null;
         try {
-            monitor = monitorsApi.getMonitor(model.getID().longValue(), null);
+            monitor = monitorsApi.getMonitor(model.getId().longValue(), null);
         } catch(ApiException e) {
             String err = "Failed to get monitor: " + e.toString();
             logger.log(err);
@@ -48,7 +48,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                 .build();
         }
 
-        model.setID(monitor.getId().doubleValue());
+        model.setId(monitor.getId().doubleValue());
         model.setCreated(monitor.getCreated().toString());
         model.setModified(monitor.getCreated().toString());
         if(monitor.getDeleted() != null)

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/UpdateHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/UpdateHandler.java
@@ -103,7 +103,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             .multi(model.getMulti());
 
         try {
-            monitorsApi.editMonitor(model.getID().longValue(), monitor);
+            monitorsApi.editMonitor(model.getId().longValue(), monitor);
         } catch(ApiException e) {
             String err = "Failed to update monitor: " + e.toString();
             logger.log(err);

--- a/datadog-monitors-monitor-handler/src/test/java/com/datadog/monitors/monitor/MonitorCRUDTest.java
+++ b/datadog-monitors-monitor-handler/src/test/java/com/datadog/monitors/monitor/MonitorCRUDTest.java
@@ -51,7 +51,7 @@ public class MonitorCRUDTest {
     public void deleteMonitor() {
         final DeleteHandler deleteHandler = new DeleteHandler();
         final ResourceModel model = ResourceModel.builder().build();
-        model.setID(id);
+        model.setId(id);
         model.setDatadogCredentials(datadogCredentials);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -100,7 +100,7 @@ public class MonitorCRUDTest {
         assertThat(read.getTags()).isEqualTo(testTags);
         assertThat(read.getOptions().getThresholds().getCritical()).isEqualTo(3.);
         assertThat(read.getOptions().getThresholds().getOK()).isEqualTo(2.);
-        id = read.getID();
+        id = read.getId();
 
         // Update the resource
         options = new MonitorOptions();


### PR DESCRIPTION
There was an odd behavior where, the ID being uppercase in the schema would cause two fields to be set in the model after the first run, an `ID` and an `Id`. I believe this has to do with some underlying logic in relation to the primaryIdentifier field but haven't fully found a root cause there. 

However, using this more standard `Id` casing allows a single value to be used across runs and fixes the error we were previously seeing:

```
validation failed (#: extraneous key [id] is not permitted).
```