### PR TITLE
Add missing testEntrypoint and schema handlers

### DIFF
--- a/datadog-iam-user-handler/.rpdk-config
+++ b/datadog-iam-user-handler/.rpdk-config
@@ -10,5 +10,6 @@
             "iam",
             "user"
         ]
-    }
+    },
+    "testEntrypoint": "com.datadog.iam.user.HandlerWrapper::testEntrypoint"
 }

--- a/datadog-iam-user-handler/datadog-iam-user.json
+++ b/datadog-iam-user-handler/datadog-iam-user.json
@@ -60,5 +60,22 @@
         "DatadogCredentials",
         "Handle"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "handlers": {
+        "create": {
+            "permissions": [""]
+        },
+        "read": {
+            "permissions": [""]
+        },
+        "update": {
+            "permissions": [""]
+        },
+        "delete": {
+            "permissions": [""]
+        },
+        "list": {
+            "permissions": [""]
+        }
+    }
 }

--- a/datadog-integrations-aws-handler/.rpdk-config
+++ b/datadog-integrations-aws-handler/.rpdk-config
@@ -10,5 +10,6 @@
             "integrations",
             "aws"
         ]
-    }
+    },
+    "testEntrypoint": "com.datadog.integrations.aws.HandlerWrapper::testEntrypoint"
 }

--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -66,5 +66,22 @@
         "/properties/AccessKeyID",
         "/properties/RoleName"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "handlers": {
+        "create": {
+            "permissions": [""]
+        },
+        "read": {
+            "permissions": [""]
+        },
+        "update": {
+            "permissions": [""]
+        },
+        "delete": {
+            "permissions": [""]
+        },
+        "list": {
+            "permissions": [""]
+        }
+    }
 }

--- a/datadog-monitors-downtime-handler/.rpdk-config
+++ b/datadog-monitors-downtime-handler/.rpdk-config
@@ -10,5 +10,6 @@
             "monitors",
             "downtime"
         ]
-    }
+    },
+    "testEntrypoint": "com.datadog.monitors.downtime.HandlerWrapper::testEntrypoint"
 }

--- a/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
+++ b/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
@@ -160,5 +160,22 @@
     "required": [
         "Scope",
         "DatadogCredentials"
-    ]
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [""]
+        },
+        "read": {
+            "permissions": [""]
+        },
+        "update": {
+            "permissions": [""]
+        },
+        "delete": {
+            "permissions": [""]
+        },
+        "list": {
+            "permissions": [""]
+        }
+    }
 }

--- a/datadog-monitors-monitor-handler/.rpdk-config
+++ b/datadog-monitors-monitor-handler/.rpdk-config
@@ -10,5 +10,6 @@
             "monitors",
             "monitor"
         ]
-    }
+    },
+    "testEntrypoint": "com.datadog.monitors.monitor.HandlerWrapper::testEntrypoint"
 }

--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -356,5 +356,22 @@
         "/properties/Creator",
         "/properties/Created"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "handlers": {
+        "create": {
+            "permissions": [""]
+        },
+        "read": {
+            "permissions": [""]
+        },
+        "update": {
+            "permissions": [""]
+        },
+        "delete": {
+            "permissions": [""]
+        },
+        "list": {
+            "permissions": [""]
+        }
+    }
 }


### PR DESCRIPTION
The latest version of the rpdk requires `testEntrypoint` to be included in the `.rpdk-config` file. This can be the same as the handler from the TestEntrypoint section in the SAM Template file. 

Its also now required that each resource's schema has a `handlers` section that dictates each CRUD operation and any specific permissions needed. Our resources don't requires any specific permissions, so these are empty strings (the field is required)