### PR TITLE
Use single required ID field

### DIFF
--- a/datadog-integrations-aws-handler/README.md
+++ b/datadog-integrations-aws-handler/README.md
@@ -19,6 +19,8 @@ Resources:
         ApplicationKey: <DD_APP_KEY>
 ```
 
+**Note** The AccountID, RoleName, and AccessKeyID cannot be updated. To update these fields, you must delete and recreate the stack.
+
 ## Property Reference:
 
 For a list of available properties and their descriptions and examples, see the [JSON Schema for this resource](https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-integrations-aws-handler/datadog-integrations-aws.json).

--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -56,15 +56,25 @@
                     "type": "boolean"
                 }
             }
+        },
+        "IntegrationID": {
+            "description": "An identification value that represents this integration object. Combines the AccountID, RoleName, and AccessKeyID. This shouldn't be set in a stack.",
+            "type": "string"
         }
     },
     "required": [
         "DatadogCredentials"
     ],
     "primaryIdentifier": [
-        "/properties/AccountID",
-        "/properties/AccessKeyID",
-        "/properties/RoleName"
+        "/properties/IntegrationID"
+    ],
+    "createOnlyProperties": [
+        "/properties/accountID",
+        "/properties/RoleName",
+        "/properties/AccessKeyID"
+    ],
+    "readOnlyProperties": [
+        "/properties/IntegrationID"
     ],
     "additionalProperties": false,
     "handlers": {

--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/CreateHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/CreateHandler.java
@@ -1,14 +1,10 @@
 package com.datadog.integrations.aws;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
 import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
-
 import com.datadog.api.client.v1.ApiClient;
 import com.datadog.api.client.v1.ApiException;
 import com.datadog.api.client.v1.api.AwsIntegrationApi;
@@ -53,6 +49,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .message(err)
                 .build();
         }
+
+        String integrationID = model.getAccountID() + ":" + model.getRoleName() + ":" + model.getAccessKeyID();
+        model.setIntegrationID(integrationID);
 
         return new ReadHandler().handleRequest(proxy, request, callbackContext, logger);
     }


### PR DESCRIPTION
Resolves the internal failure issues by using a single IntegrationID field as the primaryIdentifier that always contains a value. 

My editor also seems to have removed some unneeded imports. 

Since the primaryIdentifier was a set of three fields, not all of which was required, the creation of the stack was failing with `Internal Failure`. Based on suggestion, we set the primaryID to a field that we set only on Create (simply the previous three fields concatenated). This value should only be used to internally retrieve the stack object and when a person specifies the Fn:Ref for this resource - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html