### PR TITLE
Update the AWS handler based on the newest SDK changes

### DIFF
--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/ReadHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/ReadHandler.java
@@ -38,7 +38,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
 
         AWSAccount awsAccount = null;
         try {
-            awsAccount = awsApi.getAllAWSAccounts(model.getAccountID(), model.getRoleName(), model.getAccessKeyID()).get("accounts").get(0);
+            awsAccount = awsApi.getAllAWSAccounts(model.getAccountID(), model.getRoleName(), model.getAccessKeyID()).getAccounts().get(0);
         } catch (ApiException e) {
             String err = "Failed to read AWS Integration Account: " + e.toString();
             logger.log(err);


### PR DESCRIPTION
### What does this PR do?

With the latest SDK changes, some objects around the AWS integration endpoint have changed, the aws integration handler also doesn't seem to use the return value of the Create/Update methods so they didn't require updating. This makes sure we're using the newest objects. Monitors handler doesn't appear to need changes. 
