### PR TITLE
Updated dependency for aws-cloudformation-rpdk-java-plugin

### DIFF
--- a/datadog-iam-user-handler/bin/pom.xml
+++ b/datadog-iam-user-handler/bin/pom.xml
@@ -28,7 +28,7 @@
     <dependencies>
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
-            <groupId>com.amazonaws.cloudformation</groupId>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>1.0</version>
         </dependency>

--- a/datadog-iam-user-handler/pom.xml
+++ b/datadog-iam-user-handler/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
-            <groupId>com.amazonaws.cloudformation</groupId>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>1.0</version>
         </dependency>

--- a/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/CreateHandler.java
+++ b/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/CreateHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.iam.user;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/DeleteHandler.java
+++ b/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/DeleteHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.iam.user;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/ListHandler.java
+++ b/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/ListHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.iam.user;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/ReadHandler.java
+++ b/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/ReadHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.iam.user;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/UpdateHandler.java
+++ b/datadog-iam-user-handler/src/main/java/com/datadog/iam/user/UpdateHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.iam.user;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-iam-user-handler/src/test/java/com/datadog/iam/user/UserCRUDTest.java
+++ b/datadog-iam-user-handler/src/test/java/com/datadog/iam/user/UserCRUDTest.java
@@ -1,10 +1,10 @@
 package com.datadog.iam.user;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/datadog-integrations-aws-handler/pom.xml
+++ b/datadog-integrations-aws-handler/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
-            <groupId>com.amazonaws.cloudformation</groupId>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>1.0</version>
         </dependency>

--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/CreateHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/CreateHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.integrations.aws;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import com.datadog.api.v1.client.ApiClient;
 import com.datadog.api.v1.client.ApiException;
 import com.datadog.api.v1.client.api.AwsIntegrationApi;

--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/DeleteHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/DeleteHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.integrations.aws;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/ListHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/ListHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.integrations.aws;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/ReadHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/ReadHandler.java
@@ -3,11 +3,11 @@ package com.datadog.integrations.aws;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/UpdateHandler.java
+++ b/datadog-integrations-aws-handler/src/main/java/com/datadog/integrations/aws/UpdateHandler.java
@@ -3,11 +3,11 @@ package com.datadog.integrations.aws;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-integrations-aws-handler/src/test/java/com/datadog/integrations/aws/AWSCRUDTest.java
+++ b/datadog-integrations-aws-handler/src/test/java/com/datadog/integrations/aws/AWSCRUDTest.java
@@ -1,10 +1,10 @@
 package com.datadog.integrations.aws;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/datadog-monitors-downtime-handler/pom.xml
+++ b/datadog-monitors-downtime-handler/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
-            <groupId>com.amazonaws.cloudformation</groupId>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>1.0</version>
         </dependency>

--- a/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/CreateHandler.java
+++ b/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/CreateHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.downtime;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import com.datadog.api.v1.client.ApiClient;
 import com.datadog.api.v1.client.ApiException;
 import com.datadog.api.v1.client.api.DowntimesApi;

--- a/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/DeleteHandler.java
+++ b/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/DeleteHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.downtime;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import com.datadog.api.v1.client.ApiClient;
 import com.datadog.api.v1.client.api.DowntimesApi;
 import com.datadog.cloudformation.common.clients.ApiClients;

--- a/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/ListHandler.java
+++ b/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/ListHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.downtime;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/ReadHandler.java
+++ b/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/ReadHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.downtime;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import com.datadog.api.v1.client.ApiClient;
 import com.datadog.api.v1.client.ApiException;
 import com.datadog.api.v1.client.api.DowntimesApi;

--- a/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/UpdateHandler.java
+++ b/datadog-monitors-downtime-handler/src/main/java/com/datadog/monitors/downtime/UpdateHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.downtime;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import com.datadog.api.v1.client.ApiClient;
 import com.datadog.api.v1.client.ApiException;
 import com.datadog.api.v1.client.api.DowntimesApi;

--- a/datadog-monitors-downtime-handler/src/test/java/com/datadog/monitors/downtime/DowntimeCRUDTest.java
+++ b/datadog-monitors-downtime-handler/src/test/java/com/datadog/monitors/downtime/DowntimeCRUDTest.java
@@ -8,11 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/datadog-monitors-monitor-handler/pom.xml
+++ b/datadog-monitors-monitor-handler/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
-            <groupId>com.amazonaws.cloudformation</groupId>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>1.0</version>
         </dependency>

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/CreateHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/CreateHandler.java
@@ -2,11 +2,11 @@ package com.datadog.monitors.monitor;
 
 import java.util.stream.Collectors;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/DeleteHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/DeleteHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.monitor;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/ListHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/ListHandler.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.monitor;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/ReadHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/ReadHandler.java
@@ -4,11 +4,11 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.cloudformation.common.clients.ApiClients;
 

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/UpdateHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/UpdateHandler.java
@@ -2,11 +2,11 @@ package com.datadog.monitors.monitor;
 
 import java.util.stream.Collectors;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.datadog.api.v1.client.ApiClient;
 import com.datadog.api.v1.client.ApiException;

--- a/datadog-monitors-monitor-handler/src/test/java/com/datadog/monitors/monitor/MonitorCRUDTest.java
+++ b/datadog-monitors-monitor-handler/src/test/java/com/datadog/monitors/monitor/MonitorCRUDTest.java
@@ -1,10 +1,10 @@
 package com.datadog.monitors.monitor;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
### What does this PR do?

CloudFormation had to adjust the package name for the `aws-cloudformation-rpdk-java-plugin` prior to publishing to Maven Central. This PR updates the dependencies in the DataDog providers.

### Motivation

Pre-release fixes.

### Additional Notes

Thanks for the hard work! Love this one! 😄 
