### PR TITLE
Add missing downtime property to schema def

### DIFF
--- a/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
+++ b/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
@@ -152,6 +152,7 @@
         "/properties/ParentId",
         "/properties/UpdaterId"
     ],
+    "additionalProperties": false,
     "required": [
         "Scope",
         "DatadogCredentials"


### PR DESCRIPTION
### What does this PR do?

`additionalProperties` needs to be set in the root schema as its a required property. Its in the other handlers, but was missing for downtimes. 

### Motivation

As its a required field, the build failed without this. 