### PR TITLE
Prep next release, clarify docs

### DIFF
--- a/datadog-cloudformation-common/pom.xml
+++ b/datadog-cloudformation-common/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.datadoghq</groupId>
     <artifactId>datadog-cloudformation-common</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>datadog-cloudformation-common</name>
     <dependencies>
         <dependency>

--- a/datadog-iam-user-handler/README.md
+++ b/datadog-iam-user-handler/README.md
@@ -9,6 +9,7 @@ Resources:
   DatadogTestUser:
     Type: 'Datadog::IAM::User'
     Properties:
+      ApiURL: https://api.datadoghq.com
       AccessRole: st
       Email: test@example.com
       Handle: test@example.com

--- a/datadog-iam-user-handler/README.md
+++ b/datadog-iam-user-handler/README.md
@@ -9,12 +9,12 @@ Resources:
   DatadogTestUser:
     Type: 'Datadog::IAM::User'
     Properties:
-      ApiURL: https://api.datadoghq.com
       AccessRole: st
       Email: test@example.com
       Handle: test@example.com
       Name: Test LastName
       DatadogCredentials:
+        ApiURL: https://api.datadoghq.com
         ApiKey: <DD_API_KEY>
         ApplicationKey: <DD_APP_KEY>
 ```

--- a/datadog-iam-user-handler/pom.xml
+++ b/datadog-iam-user-handler/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.datadoghq</groupId>
     <artifactId>datadog-iam-user-cloudformation-handler</artifactId>
     <name>datadog-iam-user-cloudformation-handler</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/datadog-integrations-aws-handler/README.md
+++ b/datadog-integrations-aws-handler/README.md
@@ -9,13 +9,13 @@ Resources:
   DatadogTestAWSAccount:
     Type: 'Datadog::Integrations::AWS'
     Properties:
-      ApiURL: https://api.datadoghq.com
       AccountID: 123456
       RoleName: DatadogAWSAcctRoleName
       FilterTags: ["filter:thisTag"]
       HostTags: ["env:staging", "account:123456"]
       AccountSpecificNamespaceRules: {"api_gateway": true, "route53": false}
       DatadogCredentials:
+        ApiURL: https://api.datadoghq.com
         ApiKey: <DD_API_KEY>
         ApplicationKey: <DD_APP_KEY>
 ```

--- a/datadog-integrations-aws-handler/README.md
+++ b/datadog-integrations-aws-handler/README.md
@@ -9,6 +9,7 @@ Resources:
   DatadogTestAWSAccount:
     Type: 'Datadog::Integrations::AWS'
     Properties:
+      ApiURL: https://api.datadoghq.com
       AccountID: 123456
       RoleName: DatadogAWSAcctRoleName
       FilterTags: ["filter:thisTag"]

--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -14,7 +14,7 @@
                     "type": "string"
                 },
                 "ApiURL": {
-                    "description": "Datadog API URL (defaults to https://api.datadoghq.com)",
+                    "description": "Datadog API URL (defaults to https://api.datadoghq.com) Use https://api.datadoghq.eu for EU accounts.",
                     "type": "string"
                 }
             },

--- a/datadog-integrations-aws-handler/pom.xml
+++ b/datadog-integrations-aws-handler/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.datadoghq</groupId>
     <artifactId>datadog-integrations-aws-cloudformation-handler</artifactId>
     <name>datadog-integrations-aws-cloudformation-handler</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/datadog-monitors-downtime-handler/README.md
+++ b/datadog-monitors-downtime-handler/README.md
@@ -11,7 +11,6 @@ Resources:
   DatadogTestDowntimeUntilDate:
     Type: 'Datadog::Monitors::Downtime'
     Properties:
-      ApiURL: https://api.datadoghq.com
       Message: "Setting downtime on this monitor during regular maintenance"
       MonitorId: 12345
       Scope: ["*"]
@@ -19,6 +18,7 @@ Resources:
       End: 1569628800
       Timezone: "EST"
       DatadogCredentials:
+        ApiURL: https://api.datadoghq.com
         ApiKey: <DD_API_KEY>
         ApplicationKey: <DD_APP_KEY>
 ```

--- a/datadog-monitors-downtime-handler/README.md
+++ b/datadog-monitors-downtime-handler/README.md
@@ -11,6 +11,7 @@ Resources:
   DatadogTestDowntimeUntilDate:
     Type: 'Datadog::Monitors::Downtime'
     Properties:
+      ApiURL: https://api.datadoghq.com
       Message: "Setting downtime on this monitor during regular maintenance"
       MonitorId: 12345
       Scope: ["*"]

--- a/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
+++ b/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
@@ -70,7 +70,7 @@
                     "type": "string"
                 },
                 "ApiURL": {
-                    "description": "Datadog API URL (defaults to https://api.datadoghq.com)",
+                    "description": "Datadog API URL (defaults to https://api.datadoghq.com) Use https://api.datadoghq.eu for EU accounts.",
                     "type": "string"
                 }
             },

--- a/datadog-monitors-downtime-handler/pom.xml
+++ b/datadog-monitors-downtime-handler/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.datadoghq</groupId>
     <artifactId>datadog-monitors-downtime-cloudformation-handler</artifactId>
     <name>datadog-monitors-downtime-cloudformation-handler</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/datadog-monitors-monitor-handler/README.md
+++ b/datadog-monitors-monitor-handler/README.md
@@ -9,6 +9,7 @@ Resources:
   DatadogTestMonitor:
     Type: 'Datadog::Monitors::Monitor'
     Properties:
+      ApiURL: https://api.datadoghq.com
       Type: query alert
       Query: 'avg(last_1h):sum:system.cpu.system{host:host0} > 100'
       Name: Test Monitor
@@ -16,7 +17,7 @@ Resources:
         Thresholds:
           Critical: 100
           Warning: 80
-          Ok: 90
+          OK: 90
         NotifyNoData: true
         EvaluationDelay: 60
       DatadogCredentials:

--- a/datadog-monitors-monitor-handler/README.md
+++ b/datadog-monitors-monitor-handler/README.md
@@ -9,7 +9,6 @@ Resources:
   DatadogTestMonitor:
     Type: 'Datadog::Monitors::Monitor'
     Properties:
-      ApiURL: https://api.datadoghq.com
       Type: query alert
       Query: 'avg(last_1h):sum:system.cpu.system{host:host0} > 100'
       Name: Test Monitor
@@ -21,6 +20,7 @@ Resources:
         NotifyNoData: true
         EvaluationDelay: 60
       DatadogCredentials:
+        ApiURL: https://api.datadoghq.com
         ApiKey: <DD_API_KEY>
         ApplicationKey: <DD_APP_KEY>
 ```

--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -257,7 +257,7 @@
                     "type": "string"
                 },
                 "ApiURL": {
-                    "description": "Datadog API URL (defaults to https://api.datadoghq.com)",
+                    "description": "Datadog API URL (defaults to https://api.datadoghq.com) Use https://api.datadoghq.eu for EU accounts.",
                     "type": "string"
                 }
             },

--- a/datadog-monitors-monitor-handler/pom.xml
+++ b/datadog-monitors-monitor-handler/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.datadoghq</groupId>
     <artifactId>datadog-monitors-monitor-cloudformation-handler</artifactId>
     <name>datadog-monitors-monitor-cloudformation-handler</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
### What does this PR do?

* Bump the resources to 1.0.1 version
* Update the README of each resource to include the new ApiURL with an example of how to switch to EU
* Fix up the Monitor resource Readme to use the proper casing for the `OK` threshold. 

### Motivation

Prep the next 1.0.1 release
