### PR TITLE
Bump the common package dep version

### DIFF
--- a/datadog-iam-user-handler/pom.xml
+++ b/datadog-iam-user-handler/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <datadog-api-client-version>1.0.0</datadog-api-client-version>
-        <datadog-cloudformation-common-version>1.0.0</datadog-cloudformation-common-version>
+        <datadog-cloudformation-common-version>1.0.1</datadog-cloudformation-common-version>
     </properties>
 
     <repositories>

--- a/datadog-integrations-aws-handler/pom.xml
+++ b/datadog-integrations-aws-handler/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <datadog-api-client-version>1.0.0</datadog-api-client-version>
-        <datadog-cloudformation-common-version>1.0.0</datadog-cloudformation-common-version>
+        <datadog-cloudformation-common-version>1.0.1</datadog-cloudformation-common-version>
     </properties>
 
     <repositories>

--- a/datadog-monitors-downtime-handler/pom.xml
+++ b/datadog-monitors-downtime-handler/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <datadog-api-client-version>1.0.0</datadog-api-client-version>
-        <datadog-cloudformation-common-version>1.0.0</datadog-cloudformation-common-version>
+        <datadog-cloudformation-common-version>1.0.1</datadog-cloudformation-common-version>
     </properties>
 
     <repositories>

--- a/datadog-monitors-monitor-handler/pom.xml
+++ b/datadog-monitors-monitor-handler/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <datadog-api-client-version>1.0.0</datadog-api-client-version>
-        <datadog-cloudformation-common-version>1.0.0</datadog-cloudformation-common-version>
+        <datadog-cloudformation-common-version>1.0.1</datadog-cloudformation-common-version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### What does this PR do?

Bump the cloudformation-common deps in each resource to the new 1.0.1 version

### Motivation

Use the latest datadog-cloudformation-common package

