### PR TITLE
Move to new client version which uses Doubles instead of Floats, fix Monitor tests

### DIFF
--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/CreateHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/CreateHandler.java
@@ -64,15 +64,15 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             if (model.getOptions().getThresholds() != null) {
                 thresholds = new MonitorThresholds();
                 if(model.getOptions().getThresholds().getCritical() != null)
-                    thresholds.critical(model.getOptions().getThresholds().getCritical().floatValue());
+                    thresholds.critical(model.getOptions().getThresholds().getCritical());
                 if(model.getOptions().getThresholds().getCriticalRecovery() != null)
-                    thresholds.criticalRecovery(model.getOptions().getThresholds().getCriticalRecovery().floatValue());
+                    thresholds.criticalRecovery(model.getOptions().getThresholds().getCriticalRecovery());
                 if(model.getOptions().getThresholds().getOK() != null)
-                    thresholds.ok(model.getOptions().getThresholds().getOK().floatValue());
+                    thresholds.ok(model.getOptions().getThresholds().getOK());
                 if(model.getOptions().getThresholds().getWarning() != null)
-                    thresholds.warning(model.getOptions().getThresholds().getWarning().floatValue());
+                    thresholds.warning(model.getOptions().getThresholds().getWarning());
                 if(model.getOptions().getThresholds().getWarningRecovery() != null)
-                    thresholds.warningRecovery(model.getOptions().getThresholds().getWarningRecovery().floatValue());
+                    thresholds.warningRecovery(model.getOptions().getThresholds().getWarningRecovery());
             }
             options.thresholds(thresholds);
 

--- a/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/UpdateHandler.java
+++ b/datadog-monitors-monitor-handler/src/main/java/com/datadog/monitors/monitor/UpdateHandler.java
@@ -66,15 +66,15 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             if (model.getOptions().getThresholds() != null) {
                 thresholds = new MonitorThresholds();
                 if(model.getOptions().getThresholds().getCritical() != null)
-                    thresholds.setCritical(model.getOptions().getThresholds().getCritical().floatValue());
+                    thresholds.setCritical(model.getOptions().getThresholds().getCritical());
                 if(model.getOptions().getThresholds().getCriticalRecovery() != null)
-                    thresholds.setCriticalRecovery(model.getOptions().getThresholds().getCriticalRecovery().floatValue());
+                    thresholds.setCriticalRecovery(model.getOptions().getThresholds().getCriticalRecovery());
                 if(model.getOptions().getThresholds().getWarning() != null)
-                    thresholds.setWarning(model.getOptions().getThresholds().getWarning().floatValue());
+                    thresholds.setWarning(model.getOptions().getThresholds().getWarning());
                 if(model.getOptions().getThresholds().getWarningRecovery() != null)
-                    thresholds.setWarningRecovery(model.getOptions().getThresholds().getWarningRecovery().floatValue());
+                    thresholds.setWarningRecovery(model.getOptions().getThresholds().getWarningRecovery());
                 if(model.getOptions().getThresholds().getOK() != null)
-                    thresholds.setOk(model.getOptions().getThresholds().getOK().floatValue());
+                    thresholds.setOk(model.getOptions().getThresholds().getOK());
             }
             options.thresholds(thresholds);
 

--- a/datadog-monitors-monitor-handler/src/test/java/com/datadog/monitors/monitor/MonitorCRUDTest.java
+++ b/datadog-monitors-monitor-handler/src/test/java/com/datadog/monitors/monitor/MonitorCRUDTest.java
@@ -73,12 +73,12 @@ public class MonitorCRUDTest {
         final ResourceModel model = ResourceModel.builder().build();
         model.setTags(testTags);
         model.setDatadogCredentials(datadogCredentials);
-        model.setType("service check");
-        model.setQuery("\"ntp.in_sync\".over(\"*\").last(2).count_by_status()");
+        model.setType("query alert");
+        model.setQuery("avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100");
         MonitorOptions options = new MonitorOptions();
         MonitorThresholds thresholds = new MonitorThresholds();
-        thresholds.setCritical(3.);
-        thresholds.setOK(2.);
+        thresholds.setCritical(100.);
+        thresholds.setOK(50.);
         options.setThresholds(thresholds);
         model.setOptions(options);
 
@@ -102,8 +102,8 @@ public class MonitorCRUDTest {
 
         ResourceModel read = response.getResourceModel();
         assertThat(read.getTags()).isEqualTo(testTags);
-        assertThat(read.getOptions().getThresholds().getCritical()).isEqualTo(3.);
-        assertThat(read.getOptions().getThresholds().getOK()).isEqualTo(2.);
+        assertThat(read.getOptions().getThresholds().getCritical()).isEqualTo(100.);
+        assertThat(read.getOptions().getThresholds().getOK()).isEqualTo(50.);
         id = read.getId();
 
         // Update the resource
@@ -124,11 +124,11 @@ public class MonitorCRUDTest {
         options.setRenotifyInterval(10.);
 
         thresholds = new MonitorThresholds();
-        thresholds.setCritical(.1);
-        thresholds.setCriticalRecovery(.09);
-        thresholds.setOK(.02);
-        thresholds.setWarning(.05);
-        thresholds.setWarningRecovery(.04);
+        thresholds.setCritical(1.);
+        thresholds.setCriticalRecovery(0.5);
+        thresholds.setOK(0.25);
+        thresholds.setWarning(0.45);
+        thresholds.setWarningRecovery(0.4);
         options.setThresholds(thresholds);
 
         MonitorThresholdWindows thresholdWindows = new MonitorThresholdWindows();
@@ -138,9 +138,8 @@ public class MonitorCRUDTest {
 
         model.setOptions(options);
         model.setTags(testTagsUpdated);
-        String updatedQuery = "avg(last_4h):anomalies(avg:datadog.estimated_usage.containers{*}, 'basic', 2, direction='both', alert_window='last_30m', interval=60, count_default_zero='true') >= 0.1";
+        String updatedQuery = "avg(last_1h):anomalies(avg:system.net.bytes_rcvd{host:host0}, 'basic', 2, direction='both', alert_window='last_30m', interval=120, count_default_zero='true') >= 1";
         model.setQuery(updatedQuery);
-        model.setType("metric alert");
         model.setMessage("updated message");
         model.setName("updated name");
 
@@ -157,7 +156,7 @@ public class MonitorCRUDTest {
         assertThat(updateRead.getQuery()).isEqualTo(updatedQuery);
         assertThat(updateRead.getMessage()).isEqualTo("updated message");
         assertThat(updateRead.getName()).isEqualTo("updated name");
-        assertThat(updateRead.getType()).isEqualTo("metric alert");
+        assertThat(updateRead.getType()).isEqualTo("query alert");
         assertThat(updateRead.getOptions().getAggregation()).isEqualTo("in total");
         assertThat(updateRead.getOptions().getEnableLogsSample()).isTrue();
         assertThat(updateRead.getOptions().getEscalationMessage()).isEqualTo("escalation message");
@@ -172,11 +171,11 @@ public class MonitorCRUDTest {
         assertThat(updateRead.getOptions().getNewHostDelay()).isEqualTo(10.);
         assertThat(updateRead.getOptions().getNoDataTimeframe()).isEqualTo(20.);
         assertThat(updateRead.getOptions().getRenotifyInterval()).isEqualTo(10.);
-        assertThat(updateRead.getOptions().getThresholds().getCritical()).isEqualTo(.1, within(.00001));
-        assertThat(updateRead.getOptions().getThresholds().getCriticalRecovery()).isEqualTo(.09, within(.00001));
-        assertThat(updateRead.getOptions().getThresholds().getOK()).isEqualTo(.02, within(.00001));
-        assertThat(updateRead.getOptions().getThresholds().getWarning()).isEqualTo(.05, within(.00001));
-        assertThat(updateRead.getOptions().getThresholds().getWarningRecovery()).isEqualTo(.04, within(.00001));
+        assertThat(updateRead.getOptions().getThresholds().getCritical()).isEqualTo(1., within(.00001));
+        assertThat(updateRead.getOptions().getThresholds().getCriticalRecovery()).isEqualTo(0.5, within(.00001));
+        assertThat(updateRead.getOptions().getThresholds().getOK()).isEqualTo(.25, within(.00001));
+        assertThat(updateRead.getOptions().getThresholds().getWarning()).isEqualTo(.45, within(.00001));
+        assertThat(updateRead.getOptions().getThresholds().getWarningRecovery()).isEqualTo(.4, within(.00001));
         assertThat(updateRead.getOptions().getThresholdWindows().getTriggerWindow()).isEqualTo("last_30m");
         assertThat(updateRead.getOptions().getThresholdWindows().getRecoveryWindow()).isEqualTo("last_30m");
     }


### PR DESCRIPTION
### What does this PR do?

Moves to new version of the client which moved all Float fields to Double fields. Fixes rounding errors for high Monitor threshold values.

Additionally, the tests for monitor handler didn't really work, so I fixed them to actually pass.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
