### PR TITLE
make it easier to discover package version links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following Datadog resources can be registered within your AWS account, refer
 |-------------------------|-------------------------------|---------------------------------------------------------|-----------------------------|----------------|
 | Datadog-AWS integration | `Datadog::Integrations::AWS`  | [Manage your Datadog-Amazon Web Service integration][5] | `datadog-integrations-aws`  | [Schema Handler Versions][6]  |
 | Monitors                | `Datadog::Monitors::Monitor`  | [Create, update, and delete Datadog monitors][7].       | `datadog-monitors-monitor`  | [Schema Handler Versions][8]  |
-| Downtimes               | `Datadog::Monitors::Downtime` | [Enable or Disable downtimes for your monitors][9].     | `datadog-monitors-downtime` | [Schema Handler Versions][10]  |
+| Downtimes               | `Datadog::Monitors::Downtime` | [Enable or disable downtimes for your monitors][9].     | `datadog-monitors-downtime` | [Schema Handler Versions][10]  |
 | User                    | `Datadog::IAM::User`          | [ Create and manage Datadog users][11].                 | `datadog-iam-user`          | [Schema Handler Versions][12] |
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ For more information about the available commands and workflows, see the the off
 
 The following Datadog resources can be registered within your AWS account, refer to their specific documentation to see how to configure them:
 
-| Resource                | Name                          | Description                                             | Folder                      | Resource Link  |
+| Resource                | Name                          | Description                                             | Folder                      | S3 Package Links  |
 |-------------------------|-------------------------------|---------------------------------------------------------|-----------------------------|----------------|
-| Datadog-AWS integration | `Datadog::Integrations::AWS`  | [Manage your Datadog-Amazon Web Service integration][5] | `datadog-integrations-aws`  | [Download][6]  |
-| Monitors                | `Datadog::Monitors::Monitor`  | [Create, update, and delete Datadog monitors][7].       | `datadog-monitors-monitor`  | [Download][8]  |
-| Downtimes               | `Datadog::Monitors::Downtime` | [Enable or Disable downtimes for your monitors][9].     | `datadog-monitors-downtime` | [Download][10]  |
-| User                    | `Datadog::IAM::User`          | [ Create and manage Datadog users][11].                 | `datadog-iam-user`          | [Download][12] |
+| Datadog-AWS integration | `Datadog::Integrations::AWS`  | [Manage your Datadog-Amazon Web Service integration][5] | `datadog-integrations-aws`  | [Schema Handler Versions][6]  |
+| Monitors                | `Datadog::Monitors::Monitor`  | [Create, update, and delete Datadog monitors][7].       | `datadog-monitors-monitor`  | [Schema Handler Versions][8]  |
+| Downtimes               | `Datadog::Monitors::Downtime` | [Enable or Disable downtimes for your monitors][9].     | `datadog-monitors-downtime` | [Schema Handler Versions][10]  |
+| User                    | `Datadog::IAM::User`          | [ Create and manage Datadog users][11].                 | `datadog-iam-user`          | [Schema Handler Versions][12] |
 
 ## Troubleshooting
 
@@ -63,11 +63,11 @@ Need help? Contact [Datadog support][13].
 [3]: https://console.aws.amazon.com/cloudformation/home
 [4]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 [5]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-integrations-aws-handler
-[6]: s3://datadog-cloudformation-resources/datadog-integrations-aws/datadog-integrations-aws-1.0.1.zip
+[6]: datadog-integrations-aws-handler/CHANGELOG.md
 [7]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-monitors-monitor-handler
-[8]: s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.1.zip
+[8]: datadog-monitors-monitor-handler/CHANGELOG.md
 [9]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-monitors-downtime-handler
-[10]: s3://datadog-cloudformation-resources/datadog-monitors-downtime/datadog-monitors-downtime-1.0.1.zip
+[10]: datadog-monitors-downtime-handler/CHANGELOG.md
 [11]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/ddatadog-iam-user-handler
-[12]: s3://datadog-cloudformation-resources/datadog-iam-user/datadog-iam-user-1.0.1.zip
+[12]: datadog-iam-user-handler/CHANGELOG.md
 [13]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

Updates the top level readme to make it easier to discover schema package version s3 links

### Motivation

Github doesn't linkify s3 links so it took me a while to figure out where to actually find the s3 links. The location of these isn't actually linked to from any rendered readme at the moment so I'm likely not alone in being stuck.

### Additional Notes

It may actually be worth calling out the changelog file from each resource directory
