### PR TITLE
Fixing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ For more information about the available commands and workflows, see the the off
 
 The following Datadog resources can be registered within your AWS account, refer to their specific documentation to see how to configure them:
 
-| Resource                | Name                          | Description                                             | Folder                      | S3 Package Links  |
-|-------------------------|-------------------------------|---------------------------------------------------------|-----------------------------|----------------|
+| Resource                | Name                          | Description                                             | Folder                      | S3 Package Links              |
+|-------------------------|-------------------------------|---------------------------------------------------------|-----------------------------|-------------------------------|
 | Datadog-AWS integration | `Datadog::Integrations::AWS`  | [Manage your Datadog-Amazon Web Service integration][5] | `datadog-integrations-aws`  | [Schema Handler Versions][6]  |
 | Monitors                | `Datadog::Monitors::Monitor`  | [Create, update, and delete Datadog monitors][7].       | `datadog-monitors-monitor`  | [Schema Handler Versions][8]  |
-| Downtimes               | `Datadog::Monitors::Downtime` | [Enable or disable downtimes for your monitors][9].     | `datadog-monitors-downtime` | [Schema Handler Versions][10]  |
+| Downtimes               | `Datadog::Monitors::Downtime` | [Enable or disable downtimes for your monitors][9].     | `datadog-monitors-downtime` | [Schema Handler Versions][10] |
 | User                    | `Datadog::IAM::User`          | [ Create and manage Datadog users][11].                 | `datadog-iam-user`          | [Schema Handler Versions][12] |
 
 ## Troubleshooting
@@ -63,11 +63,11 @@ Need help? Contact [Datadog support][13].
 [3]: https://console.aws.amazon.com/cloudformation/home
 [4]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 [5]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-integrations-aws-handler
-[6]: datadog-integrations-aws-handler/CHANGELOG.md
+[6]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-integrations-aws-handler/CHANGELOG.md
 [7]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-monitors-monitor-handler
-[8]: datadog-monitors-monitor-handler/CHANGELOG.md
+[8]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-monitors-monitor-handler/CHANGELOG.md
 [9]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-monitors-downtime-handler
-[10]: datadog-monitors-downtime-handler/CHANGELOG.md
+[10]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-monitors-downtime-handler/CHANGELOG.md
 [11]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/ddatadog-iam-user-handler
-[12]: datadog-iam-user-handler/CHANGELOG.md
+[12]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-iam-user-handler/CHANGELOG.md
 [13]: https://docs.datadoghq.com/help/

--- a/datadog-iam-user-handler/CHANGELOG.md
+++ b/datadog-iam-user-handler/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 Released on 2019-11-19
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-iam-user/datadog-iam-user-1.0.1.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-iam-user/datadog-iam-user-1.0.1.zip)
 * [FEATURE] Add ApiURL property to allow managing resource in EU accounts
 
 # 1.0.0
 
 Released on 2019-11-18
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-iam-user/datadog-iam-user-1.0.0.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-iam-user/datadog-iam-user-1.0.0.zip)
 * Initial release of the Datadog user resource for AWS CloudFormation.

--- a/datadog-integrations-aws-handler/CHANGELOG.md
+++ b/datadog-integrations-aws-handler/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 Released on 2019-11-19
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-integrations-aws/datadog-integrations-aws-1.0.1.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-integrations-aws/datadog-integrations-aws-1.0.1.zip)
 * [FEATURE] Add ApiURL property to allow managing resource in EU accounts
 
 # 1.0.0
 
 Released on 2019-11-18
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-integrations-aws/datadog-integrations-aws-1.0.0.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-integrations-aws/datadog-integrations-aws-1.0.0.zip)
 * Initial release of the Datadog AWS integration resource for AWS CloudFormation.

--- a/datadog-monitors-downtime-handler/CHANGELOG.md
+++ b/datadog-monitors-downtime-handler/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 Released on 2019-11-19
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-monitors-downtime/datadog-monitors-downtime-1.0.1.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-monitors-downtime/datadog-monitors-downtime-1.0.1.zip)
 * [FEATURE] Add ApiURL property to allow managing resource in EU accounts
 
 # 1.0.0
 
 Released on 2019-11-18
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-monitors-downtime/datadog-monitors-downtime-1.0.0.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-monitors-downtime/datadog-monitors-downtime-1.0.0.zip)
 * Initial release of the Datadog downtime resource for AWS CloudFormation.

--- a/datadog-monitors-monitor-handler/CHANGELOG.md
+++ b/datadog-monitors-monitor-handler/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 Released on 2019-11-21
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.2.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.2.zip)
 * [BUGFIX] Use `Double` for all previously `Float` values to get sufficient precision for high thresholds.
 
 # 1.0.1
 
 Released on 2019-11-19
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.1.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.1.zip)
 * [FEATURE] Add ApiURL property to allow managing resource in EU accounts
 
 # 1.0.0
 
 Released on 2019-11-18
 
-* [Link to Resource] s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.0.zip
+* [Link to Resource](s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-1.0.0.zip)
 Initial release of the Datadog monitor resource for AWS CloudFormation.


### PR DESCRIPTION
### What does this PR do?

* Fixes link in the Main readme to be absolute. Since this content is displayed in the main documentation, links need to be absolute otherwise user are redirected locally in the doc where there is no changelog

* Fixes link layout in Changelog to be more compact and readable.

### Motivation

Better doc for a better world.