### PR TITLE
Bump days before close in stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,11 +28,12 @@ jobs:
 
             1. Comment that the issue is still reproducible and include updated details requested in the issue template.
         days-before-stale: 30
+        days-before-close: 99999
         stale-issue-label: 'stale'
         exempt-issue-label: 'stale/exempt'
         stale-pr-message: >-
           This issue has been automatically marked as stale because it has not had activity in the last 30 days.
 
-          Note that the issue will not be automatically closed, but this notification will remind us to investigate why there'sbeen inactivity.
+          Note that the issue will not be automatically closed, but this notification will remind us to investigate why there's been inactivity.
         stale-pr-label: 'stale'
         exempt-pr-label: 'stale/exempt'


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

Bumps the days before close in the stale action. This has a default value of `7` if not set, and we want to not close stale issues. 

### Description of the Change

Chooses an arbitrarily large value for `days-before-close` to essentially "never" close stale issues/prs

### Alternate Designs

The stale action doesn't yet support "never" closing an issue, so I don't think there is an alternative here

### Verification Process

No manual tests done here. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
