### PR TITLE
Specify User Agent header and set monitor id on create

### DIFF
--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -14,5 +14,5 @@ def v1_client(api_key: str, app_key: str, api_url: str, resource_name: str, reso
     )
 
     with ApiClient(configuration) as api_client:
-        api_client.user_agent = f"datadog-cloudformation-{resource_name}/{resource_version} {api_client.user_agent()}"
+        api_client.user_agent = f"datadog-cloudformation-{resource_name}/{resource_version} {api_client.user_agent}"
         yield api_client

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -6,7 +6,7 @@ from datadog_api_client.v1 import ApiClient, Configuration
 @contextmanager
 def v1_client(api_key: str, app_key: str, api_url: str, resource_name: str, resource_version: str) -> ApiClient:
     configuration = Configuration(
-        host=api_url,
+        host=api_url or "https://api.datadoghq.com",
         api_key={
             "apiKeyAuth": api_key,
             "appKeyAuth": app_key,

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -13,7 +13,6 @@ def v1_client(api_key: str, app_key: str, api_url: str, resource_name: str, reso
         }
     )
 
-    # TODO: configure user-agent
-
     with ApiClient(configuration) as api_client:
+        api_client.user_agent = f"datadog-cloudformation-{resource_name}/{resource_version} {api_client.user_agent()}"
         yield api_client

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/version.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/version.py
@@ -2,4 +2,4 @@
 # under the Apache 2.0 style license (see LICENSE).
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2020-Present Datadog, Inc.
-__version__ = "0.0.1"
+__version__ = "0.0.1.dev"

--- a/datadog-monitors-monitor-handler/requirements.txt
+++ b/datadog-monitors-monitor-handler/requirements.txt
@@ -1,2 +1,2 @@
 cloudformation-cli-python-lib==2.1.1
-git+https://github.com/datadog/datadog-cloudformation-resources.git@419643217fcb4702d55c69b3d9ce5ecbb294e028#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@96a9b95ec9670a63bf6311da9259a9d81d33e969#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
@@ -226,13 +226,14 @@ def create_handler(
     ) as api_client:
         api_instance = MonitorsApi(api_client)
         try:
-            api_instance.create_monitor(monitor)
+            monitor_resp = api_instance.create_monitor(monitor)
         except ApiException as e:
             LOG.error("Exception when calling MonitorsApi->create_monitor: %s\n", e)
             return ProgressEvent(
                 status=OperationStatus.FAILED, resourceModel=model, message=f"Error creating monitor: {e}"
             )
 
+    model.Id = monitor_resp.id
     return read_handler(session, request, callback_context)
 
 


### PR DESCRIPTION
### What does this PR do?
Adds a user agent header to the cloudformation-common-python package
While testing manually with the monitor resource, I noticed the id wasn't being set on create, so I added that back in. 

### Verification Process
Tested manually using the SAM approach in the development.md file, and checked to see the header was being sent as:

```
datadog-cloudformation-monitors-monitor/2.2.0.dev datadog-api-client-python/0.1.dev92 (python 3.7.8; os Linux; arch x86_64)
```

### Additional Notes

We'll need to create a tag or release for datadog-cloudformation-common-python, and bump the requirements.txt in specify that tag. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
