### PR TITLE
Fixes from QA

### DIFF
--- a/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
+++ b/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
@@ -149,7 +149,11 @@ def delete_handler(
             return ProgressEvent(
                 status=OperationStatus.FAILED, resourceModel=model, message=f"Error deleting dashboard: {e}"
             )
-    return read_handler(session, request, callback_context)
+
+    return ProgressEvent(
+        status=OperationStatus.SUCCESS,
+        resourceModel=None,
+    )
 
 
 @resource.handler(Action.READ)


### PR DESCRIPTION
### What does this PR do?
While working on testing prior to cutting the beta releases of dashboards/monitors/users, I noticed the delete call for dashboards was failing. We shouldn't call the read handler on delete, since the dashboard is expected to no longer exist. We should return a SUCCESS with an empty model to adhere to the delete contract - https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-delete

> A delete handler MUST return SUCCESS once it reaches the desired state. (This is because there is no runtime-state stabilization for delete requests.)
> When the delete handler returns SUCCESS, the ProgressEvent object MUST NOT contain a model.

no-changelog label since this was found between releases