### PR TITLE
Remove s3 links for betas

### DIFF
--- a/datadog-dashboards-dashboard-handler/CHANGELOG.md
+++ b/datadog-dashboards-dashboard-handler/CHANGELOG.md
@@ -2,5 +2,4 @@
 
 ## 1.0.0b1 / 2020-10-30
 
-* Link to Resource: `s3://datadog-cloudformation-resources/datadog-dashboards-dashboard/datadog-dashboards-dashboard-1.0.0b1.zip`
 * [Added] Add dashboard resource. See [#93](https://github.com/DataDog/datadog-cloudformation-resources/pull/93).

--- a/datadog-iam-user-handler/CHANGELOG.md
+++ b/datadog-iam-user-handler/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.2.0b1 / 2020-10-30
-* Link to Resource: `s3://datadog-cloudformation-resources/datadog-iam-user/datadog-iam-user-1.2.0b1.zip`
+
 * [Added] Migrate the Datadog::IAM::User resource to the python 3.7 runtime. See [#91](https://github.com/DataDog/datadog-cloudformation-resources/pull/91).
 
 

--- a/datadog-monitors-monitor-handler/CHANGELOG.md
+++ b/datadog-monitors-monitor-handler/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 3.0.0b1 / 2020-10-30
 
-* Link to Resource: `s3://datadog-cloudformation-resources/datadog-monitors-monitor/datadog-monitors-monitor-3.0.0b1.zip`
 * [Changed] Migrate monitor resource to python. See [#89](https://github.com/DataDog/datadog-cloudformation-resources/pull/89).
 
 


### PR DESCRIPTION
Remove the note about finding the beta releases on s3. Instead these are available to download from the github tag. Final releases will be uploaded to s3 later. 