### PR TITLE
Bump plugin and add new build deps

### DIFF
--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -30,7 +30,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    datadog-api-client==1.0.0b2
+    datadog-api-client @ git+https://github.com/datadog/datadog-api-client-python.git@master
     cloudformation-cli-python-lib==2.1.4
 setup_requires =
     setuptools>=30.3.0

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -30,7 +30,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    datadog-api-client==1.0.0b1
+    datadog-api-client==1.0.0b2
     cloudformation-cli-python-lib==2.1.4
 setup_requires =
     setuptools>=30.3.0

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -31,13 +31,18 @@ include_package_data = True
 python_requires = >=3.7
 install_requires =
     datadog-api-client==1.0.0b1
-    cloudformation-cli-python-lib==2.1.2
+    cloudformation-cli-python-lib==2.1.3
 setup_requires =
     setuptools>=30.3.0
 
 [options.packages.find]
 exclude = tests
 where=src
+
+[options.extras_require]
+build =
+    cloudformation-cli-python-plugin==2.1.1
+    cloudformation-cli==0.1.14
 
 [flake8]
 max-line-length = 120

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -30,7 +30,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    datadog-api-client @ git+https://github.com/datadog/datadog-api-client-python.git@master
+    datadog-api-client==1.0.0b2
     cloudformation-cli-python-lib==2.1.4
 setup_requires =
     setuptools>=30.3.0

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -30,7 +30,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    datadog-api-client==1.0.0b2
+    datadog-api-client==1.0.0b3
     cloudformation-cli-python-lib==2.1.4
 setup_requires =
     setuptools>=30.3.0

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = True
 python_requires = >=3.7
 install_requires =
     datadog-api-client==1.0.0b1
-    cloudformation-cli-python-lib==2.1.3
+    cloudformation-cli-python-lib==2.1.4
 setup_requires =
     setuptools>=30.3.0
 


### PR DESCRIPTION
Bump the python plugin dependency to fix #75 

Also adds a new "build" extra dependency in setup.cfg to install the dependencies we need to run the build and submit commands. Previously you had to manually install these to be able to build and push the zip to an AWS account. 