### PR TITLE
Fix typo in downtime resource

### DIFF
--- a/datadog-monitors-downtime-handler/src/datadog_monitors_downtime/handlers.py
+++ b/datadog-monitors-downtime-handler/src/datadog_monitors_downtime/handlers.py
@@ -180,7 +180,7 @@ def read_handler(
         model.Scope = api_resp.scope
     if hasattr(api_resp, 'timezone'):
         model.Timezone = api_resp.timezone
-    if hasattr(api_repo, 'start'):
+    if hasattr(api_resp, 'start'):
         model.Start = api_resp.start
 
     # Nullable fields, these should be None or set as a value


### PR DESCRIPTION
While testing to prep for the next releases, I found a typo in a resource change that was merged earlier today. 
No changelog since this hasn't been released