### PR TITLE
Add changelog label checker

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,21 @@
+name: "Ensure labels"
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check changelog labels
+        if: false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/')
+        run: |-
+          echo "::error Add 'changelog/*' label";
+          exit 1;
+      - name: OK
+        run: echo "Thank you!"


### PR DESCRIPTION
Add a github action to confirm that each PR has a changelog label attached
Changelog labels are required to create the CHANGELOG.md files at release time