### PR TITLE
Fix the user agent header when using the python common package

### DIFF
--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import pkg_resources
 
 from datadog_api_client.v1 import ApiClient, Configuration
 
@@ -14,5 +15,10 @@ def v1_client(api_key: str, app_key: str, api_url: str, resource_name: str, reso
     )
 
     with ApiClient(configuration) as api_client:
-        api_client.user_agent = f"datadog-cloudformation-{resource_name}/{resource_version} {api_client.user_agent}"
+        try:
+            plugin_ver = pkg_resources.get_distribution('cloudformation_cli_python_lib').version
+        except ValueError:
+            # Fallback if we're unable to retrieve the plugin version for any reason
+            plugin_ver = "NA"
+        api_client.user_agent = f"aws-cloudformation-datadog/{plugin_ver} (resource-name {resource_name}; resource-version {resource_version}) {api_client.user_agent}"
         yield api_client


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

This PR updates the user agent header to be more in line with what the previous java common package had - https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-cloudformation-common/src/main/java/com/datadog/cloudformation/common/clients/ApiClients.java#L31-L34

Having the `product` be dynamic was causing some issues with parsing later. This leaves the product the same static value while keeping the dynamic resource name later in the string.