### PR TITLE
Bump datadog-api-client version

### DIFF
--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -30,7 +30,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    datadog-api-client==1.0.0b3
+    datadog-api-client==1.0.0b6
     cloudformation-cli-python-lib==2.1.5
 setup_requires =
     setuptools>=30.3.0


### PR DESCRIPTION
### What does this PR do?

Bump datadog-api-client version to 1.0.0b6