### PR TITLE
Remove downtime recurrence definition from schema

### DIFF
--- a/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
+++ b/datadog-monitors-downtime-handler/datadog-monitors-downtime.json
@@ -1,62 +1,6 @@
 {
     "typeName": "Datadog::Monitors::Downtime",
     "description": "Datadog Monitors Downtime 2.0.0",
-    "definitions": {
-        "DowntimeRecurrence": {
-            "oneOf": [
-                {
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                        "Period": {
-                            "description": "How often to repeat",
-                            "type": "integer"
-                        },
-                        "Type": {
-                            "description": "Type of recurrence, choose from: days, weeks, months, years",
-                            "type": "string"
-                        },
-                        "WeekDays": {
-                            "description": "A list of week days to repeat on; first letter must be capitalized",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "UntilDate": {
-                            "description": "The date at which the recurrence should end as a POSIX timestmap; mutually exclusive with UntilOccurrences",
-                            "type": "integer"
-                        }
-                    }
-                },
-                {
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                        "Period": {
-                            "description": "How often to repeat",
-                            "type": "integer"
-                        },
-                        "Type": {
-                            "description": "Type of recurrence, choose from: days, weeks, months, years",
-                            "type": "string"
-                        },
-                        "WeekDays": {
-                            "description": "A list of week days to repeat on; first letter must be capitalized",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "UntilOccurrences": {
-                            "description": "The number of times the downtime is rescheduled; mutually exclusive with UntilDate",
-                            "type": "integer"
-                        }
-                    }
-                }
-            ]
-        }
-    },
     "properties": {
         "DatadogCredentials": {
             "description": "Credentials for the Datadog API",


### PR DESCRIPTION
Remove DowntimeRecurrence definition from schema as it is currently not being used. Will re-introduce once recurrence is supported.

Ran `cfn generate` to ensure it was not being used in the generated models.