### PR TITLE
Return ExternalID from the AWS integration resource

### DIFF
--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -64,6 +64,10 @@
         "IntegrationID": {
             "description": "An identification value that represents this integration object. Combines the AccountID, RoleName, and AccessKeyID. This shouldn't be set in a stack.",
             "type": "string"
+        },
+        "ExternalID": {
+            "description": "An unique ID that should be used in the sts:ExternalId condition of the DataDog role.",
+            "type": "string"
         }
     },
     "required": [
@@ -78,7 +82,8 @@
         "/properties/AccessKeyID"
     ],
     "readOnlyProperties": [
-        "/properties/IntegrationID"
+        "/properties/IntegrationID",
+        "/properties/ExternalID"
     ],
     "additionalProperties": false,
     "handlers": {

--- a/datadog-integrations-aws-handler/docs/README.md
+++ b/datadog-integrations-aws-handler/docs/README.md
@@ -127,3 +127,6 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 
 An identification value that represents this integration object. Combines the AccountID, RoleName, and AccessKeyID. This shouldn't be set in a stack.
 
+#### ExternalID
+
+An unique ID that should be used in the sts:ExternalId condition of the DataDog role.

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
@@ -61,7 +61,8 @@ def create_handler(
     ) as api_client:
         api_instance = AWSIntegrationApi(api_client)
         try:
-            api_instance.create_aws_account(aws_account)
+            api_resp = api_instance.create_aws_account(aws_account)
+            model.ExternalID = api_resp.external_id
         except ApiException as e:
             LOG.error("Exception when calling AWSIntegrationApi->create_aws_account: %s\n", e)
             return ProgressEvent(

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/models.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/models.py
@@ -47,6 +47,7 @@ class ResourceModel(BaseModel):
     HostTags: Optional[Sequence[str]]
     AccountSpecificNamespaceRules: Optional[MutableMapping[str, bool]]
     IntegrationID: Optional[str]
+    ExternalID: Optional[str]
 
     @classmethod
     def _deserialize(
@@ -66,6 +67,7 @@ class ResourceModel(BaseModel):
             HostTags=json_data.get("HostTags"),
             AccountSpecificNamespaceRules=json_data.get("AccountSpecificNamespaceRules"),
             IntegrationID=json_data.get("IntegrationID"),
+            ExternalID=json_data.get("ExternalID"),
         )
 
 
@@ -95,5 +97,3 @@ class DatadogCredentials(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _DatadogCredentials = DatadogCredentials
-
-


### PR DESCRIPTION
### What does this PR do?

In order to create AWS integration together with a role as a part of a CloudFormation stack we need to know the `ExternalID`. 
Closes #71.

### Description of the Change

The python API response contains `external_id`, so as I understand it's only necessary to make it available to CloudFormation.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Not verified

### Additional Notes

None

### Release Notes

None

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
