### PR TITLE
Update Datadog::Dashboards::Dashboard UPDATE handler to check/convert types of sub-models

### DIFF
--- a/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
+++ b/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
@@ -107,7 +107,7 @@ def update_handler(
             # whether or not to do type conversion, true in our case too
             # and importantly the api_client configuration, needed to perform the type conversions
             dashboard = validate_and_convert_types(
-                json_payload, (Dashboard,), ["resource_data"], True, False, configuration=api_client.configuration
+                json_payload, (Dashboard,), ["resource_data"], True, True, configuration=api_client.configuration
             )
             api_instance.update_dashboard(dashboard_id, dashboard)
         except TypeError as e:


### PR DESCRIPTION
### What does this PR do?

Fixes #127, allowing updates of `Datadog::Dashboards::Dashboard` resources created via CFT.

### Description of the Change

Sets the `validate_and_convert_types` `_check_type` arg to `True` in `update_handler`, allowing sub-models of the input value (`DashboardDefinition` JSON payload) to be deserialized into applicable DataDog API Client models.

Both `create_handler` and `update_handler` have comments indicating that this is meant to be `True`, and it is indeed `True` in the `create_handler`, but it appears to have been set to `False` for the `update_handler`. As a result, initial creation of dashboard resources succeeds, but dashboards cannot be updated after creation.

When the API client object attempts to serialize the models before sending to the DataDog REST API, it appears to assume all objects will be `OpenApiModel` subclasses. When `_check_type=False`, nested JSON objects are not deserialized to their applicable `OpenApiModel` subclasses, but instead retain their native `dict` deserialization types. This leads to the following `AttributeError`:

<details>
  <summary><code>AttributeError</code> Stack Trace</summary>

```
[ERROR]	2021-04-21T22:24:24.240Z	1819954f-6f4a-4634-b052-641b91b0af44	Exception caught
Traceback (most recent call last):
  File "/var/task/cloudformation_cli_python_lib/resource.py", line 120, in test_entrypoint
    return self._invoke_handler(session, request, action, callback_context)
  File "/var/task/cloudformation_cli_python_lib/resource.py", line 84, in _invoke_handler
    progress = handler(session, request, callback_context)
  File "/var/task/datadog_dashboards_dashboard/handlers.py", line 115, in update_handler
    api_instance.update_dashboard(dashboard_id, dashboard)
  File "/var/task/datadog_api_client/v1/api_client.py", line 757, in __call__
    return self.callable(self, *args, **kwargs)
  File "/var/task/datadog_api_client/v1/api/dashboards_api.py", line 426, in __update_dashboard
    return self.call_with_http_info(**kwargs)
  File "/var/task/datadog_api_client/v1/api_client.py", line 837, in call_with_http_info
    collection_formats=params["collection_format"],
  File "/var/task/datadog_api_client/v1/api_client.py", line 399, in call_api
    _check_type,
  File "/var/task/datadog_api_client/v1/api_client.py", line 167, in __call_api
    body = self.sanitize_for_serialization(body)
  File "/var/task/datadog_api_client/v1/api_client.py", line 257, in sanitize_for_serialization
    return {key: cls.sanitize_for_serialization(val) for key, val in model_to_dict(obj, serialize=True).items()}
  File "/var/task/datadog_api_client/v1/model_utils.py", line 1410, in model_to_dict
    result[attr] = [model_to_dict(x, serialize=serialize) for x in value]
  File "/var/task/datadog_api_client/v1/model_utils.py", line 1410, in <listcomp>
    result[attr] = [model_to_dict(x, serialize=serialize) for x in value]
  File "/var/task/datadog_api_client/v1/model_utils.py", line 1395, in model_to_dict
    if model_instance._composed_schemas:
AttributeError: 'dict' object has no attribute '_composed_schemas'
```
</details>

### Verification Process

Change was verified by using [aws-sam-cli](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) to invoke the resource provider locally:

```shell
sam local invoke TestEntrypoint --event update-event.json
```

<details>
  <summary>update-event.json</summary>

_Note that the `DatadogCredentials.ApiKey`, `DatadogCredentials.ApplicationKey`, and `Id` fields (within `request.desiredResourceState`) must be set appropriately._

```json
{
    "credentials": {
        "accessKeyId": null,
        "secretAccessKey": null,
        "sessionToken": null
    },
    "action": "UPDATE",
    "request": {
        "clientRequestToken": "",
        "desiredResourceState": {
            "Id": "xxx-yyy-zzz",
            "DashboardDefinition": "{\"title\":\"datadog-cloudformation-resources#127\",\"widgets\":[{\"definition\":{\"type\":\"note\",\"content\":\"\"}}],\"layout_type\":\"ordered\"}",
            "DatadogCredentials": {
                "ApiKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                "ApplicationKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
            }
        },
        "logicalResourceIdentifier": "TestDashboard"
    }
}
```

</details>

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
