### PR TITLE
map Multi CFN property to groupby_simple_monitor DD option

### DIFF
--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
@@ -274,7 +274,9 @@ def build_monitor_options_from_model(model: ResourceModel) -> ApiMonitorOptions:
         if model.Options.Locked is not None:
             options.locked = model.Options.Locked
         if model.Options.NotifyAudit is not None:
-            options.notify_audit = model.Options.NotifyAudit
+            options.notify_audit = model.Options.NotifyAudit 
+        if model.Options.GroupbySimpleMonitor is not None:
+            options.groupby_simple_monitor = not model.Options.GroupbySimpleMonitor
         if model.Options.NotifyNoData is not None:
             options.notify_no_data = model.Options.NotifyNoData
         if model.Options.RequireFullWindow is not None:

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
@@ -142,6 +142,7 @@ class MonitorOptions(BaseModel):
     NewHostDelay: Optional[int]
     NoDataTimeframe: Optional[int]
     NotifyAudit: Optional[bool]
+    GroupbySimpleMonitor: Optional[bool]
     NotifyNoData: Optional[bool]
     RenotifyInterval: Optional[int]
     RequireFullWindow: Optional[bool]
@@ -167,6 +168,7 @@ class MonitorOptions(BaseModel):
             NewHostDelay=json_data.get("NewHostDelay"),
             NoDataTimeframe=json_data.get("NoDataTimeframe"),
             NotifyAudit=json_data.get("NotifyAudit"),
+            GroupbySimpleMonitor=json_data.get("Multi"),
             NotifyNoData=json_data.get("NotifyNoData"),
             RenotifyInterval=json_data.get("RenotifyInterval"),
             RequireFullWindow=json_data.get("RequireFullWindow"),


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

Attempts to fix issue: #131 where the "Multi" CFN property doesn't appear to get mapped to the DD `groupby_simple_monitor` option.

### Description of the Change

Adds the `GroupbySimpleMonitor` option to the `MonitorOptions` class and maps the value to the `Multi` CFN property in the JSON manifest.

The value is then set in the `build_monitor_options_from_model()` function.

### Alternate Designs

No other designed considered.

### Possible Drawbacks

n/a

### Verification Process

I've not verified this. I've attempted to read the code and made assumptions about where the property should be mapped.

### Additional Notes

none

### Release Notes

Fixes issue where Multi CFN property does not affect the `groupby_simple_monitor` option for a DD monitor.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
