### PR TITLE
Upgrade datadog-cloudformation-common-python version

### DIFF
--- a/datadog-dashboards-dashboard-handler/requirements.txt
+++ b/datadog-dashboards-dashboard-handler/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.5#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.6#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python

--- a/datadog-iam-user-handler/requirements.txt
+++ b/datadog-iam-user-handler/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.4#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.6#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python

--- a/datadog-integrations-aws-handler/requirements.txt
+++ b/datadog-integrations-aws-handler/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.5#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.6#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python

--- a/datadog-monitors-downtime-handler/requirements.txt
+++ b/datadog-monitors-downtime-handler/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.5#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.6#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python

--- a/datadog-monitors-monitor-handler/requirements.txt
+++ b/datadog-monitors-monitor-handler/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.5#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.6#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python


### PR DESCRIPTION
### Requirements for Contributing to this repository

### What does this PR do?

This pull request bumps `common-python` to version `0.0.6` in all resources.

When this code has been released, #127 should finally be fixed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
