### PR TITLE
Use normal AWS docs link instead Chinese one

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ Need help? Contact [Datadog support][15].
 [15]: https://docs.datadoghq.com/help/
 [16]: https://aws.amazon.com/console/
 [17]: https://aws.amazon.com/secrets-manager/
-[18]: https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+[18]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
 [19]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-slos-slo-handler
 [20]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-slos-slo-handler/CHANGELOG.md


### PR DESCRIPTION
### What does this PR do?

Replaces the Chinese AWS documentation link with the "normal" one.

### Description of the Change

Link change.

### Additional Notes

Or was the usage of the Chinese AWS documentation link intended?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
