### PR TITLE
Fix link to SLO documentation

### DIFF
--- a/datadog-slos-slo-handler/README.md
+++ b/datadog-slos-slo-handler/README.md
@@ -1,8 +1,7 @@
 # Datadog::SLOs::SLO
 
 This resource represents a Datadog SLO, and is used to create and manage Datadog SLOs. More
- information about Datadog SLOs can be found in the [SLOs documentation](https://docs.datadoghq.com
- /monitors/service_level_objectives/).
+ information about Datadog SLOs can be found in the [SLOs documentation](https://docs.datadoghq.com/monitors/service_level_objectives/).
 
 ## Example Usage
 


### PR DESCRIPTION
### What does this PR do?
Fixes the rendering of the link to the SLO documentation in the README. 

### Description of the Change
Removed extra spaces in the URL that were preventing the rendering of the link.
