### PR TITLE
Store returned `external_id` secret in AWS SecretsManager

### DIFF
--- a/datadog-integrations-aws-handler/CHANGELOG.md
+++ b/datadog-integrations-aws-handler/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2.1.0 / 2021-08-20
-
-* [Added] Store returned external_id secret in AWS SecretsManager. See [#161](https://github.com/DataDog/datadog-cloudformation-resources/pull/161).
-
 ## 2.0.0 / 2021-06-28
 
 * [Added] Upgrade datadog-cloudformation-common-python version. See [#138](https://github.com/DataDog/datadog-cloudformation-resources/pull/138). Thanks [iwt-dennyschaefer](https://github.com/iwt-dennyschaefer).

--- a/datadog-integrations-aws-handler/CHANGELOG.md
+++ b/datadog-integrations-aws-handler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 / 2021-08-20
+
+* [Added] Store returned external_id secret in AWS SecretsManager. See [#161](https://github.com/DataDog/datadog-cloudformation-resources/pull/161).
+
 ## 2.0.0 / 2021-06-28
 
 * [Added] Upgrade datadog-cloudformation-common-python version. See [#138](https://github.com/DataDog/datadog-cloudformation-resources/pull/138). Thanks [iwt-dennyschaefer](https://github.com/iwt-dennyschaefer).

--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -81,7 +81,7 @@
       "type": "string"
     },
     "ExternalIDSecretName": {
-      "description": "The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id.",
+      "description": "The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id. Defaults to DatadogIntegrationExternalID. Cannot be referenced from created resource.",
       "type": "string"
     }
   },

--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -81,7 +81,7 @@
       "type": "string"
     },
     "ExternalIDSecretName": {
-      "description": "The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id. Defaults to DatadogIntegrationExternalID. Cannot be referenced from created resource.",
+      "description": "The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id. Defaults to `DatadogIntegrationExternalID`. Cannot be referenced from created resource.",
       "type": "string"
     }
   },

--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -79,6 +79,10 @@
     "IntegrationID": {
       "description": "An identification value that represents this integration object. Combines the AccountID, RoleName, and AccessKeyID. This shouldn't be set in a stack.",
       "type": "string"
+    },
+    "ExternalIDSecretName": {
+      "description": "The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id.",
+      "type": "string"
     }
   },
   "required": [],
@@ -97,7 +101,7 @@
   "handlers": {
     "create": {
       "permissions": [
-        ""
+        "secretsmanager:CreateSecret"
       ]
     },
     "read": {
@@ -112,7 +116,7 @@
     },
     "delete": {
       "permissions": [
-        ""
+        "secretsmanager:DeleteSecret"
       ]
     }
   }

--- a/datadog-integrations-aws-handler/docs/README.md
+++ b/datadog-integrations-aws-handler/docs/README.md
@@ -103,7 +103,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### ExternalIDSecretName
 
-The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id. Defaults to DatadogIntegrationExternalID. Cannot be referenced from created resource.
+The name of the AWS SecretsManager secret created in your account to hold this integration's `external_id`. Defaults to `DatadogIntegrationExternalID`. Cannot be referenced from created resource.
 
 _Required_: No
 

--- a/datadog-integrations-aws-handler/docs/README.md
+++ b/datadog-integrations-aws-handler/docs/README.md
@@ -1,6 +1,6 @@
 # Datadog::Integrations::AWS
 
-Datadog AWS Integration 1.2.0
+Datadog AWS Integration 2.0.0
 
 ## Syntax
 
@@ -18,6 +18,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#filtertags" title="FilterTags">FilterTags</a>" : <i>[ String, ... ]</i>,
         "<a href="#hosttags" title="HostTags">HostTags</a>" : <i>[ String, ... ]</i>,
         "<a href="#accountspecificnamespacerules" title="AccountSpecificNamespaceRules">AccountSpecificNamespaceRules</a>" : <i><a href="accountspecificnamespacerules.md">AccountSpecificNamespaceRules</a></i>,
+        "<a href="#externalidsecretname" title="ExternalIDSecretName">ExternalIDSecretName</a>" : <i>String</i>
     }
 }
 </pre>
@@ -35,6 +36,7 @@ Properties:
     <a href="#hosttags" title="HostTags">HostTags</a>: <i>
       - String</i>
     <a href="#accountspecificnamespacerules" title="AccountSpecificNamespaceRules">AccountSpecificNamespaceRules</a>: <i><a href="accountspecificnamespacerules.md">AccountSpecificNamespaceRules</a></i>
+    <a href="#externalidsecretname" title="ExternalIDSecretName">ExternalIDSecretName</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -96,6 +98,16 @@ An object (in the form {"namespace1":true/false, "namespace2":true/false}) that 
 _Required_: No
 
 _Type_: <a href="accountspecificnamespacerules.md">AccountSpecificNamespaceRules</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ExternalIDSecretName
+
+The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id.
+
+_Required_: No
+
+_Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/datadog-integrations-aws-handler/docs/README.md
+++ b/datadog-integrations-aws-handler/docs/README.md
@@ -103,7 +103,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### ExternalIDSecretName
 
-The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id.
+The name of the AWS SecretsManager secret we create in your account to hold this integration's external_id. Defaults to DatadogIntegrationExternalID. Cannot be referenced from created resource.
 
 _Required_: No
 

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
@@ -188,7 +188,7 @@ def delete_handler(
         secret_name = model.ExternalIDSecretName
     else:
         secret_name = DEFAULT_SECRET_NAME
-    boto_client = session.client("secretsmanager", "us-east-1")
+    boto_client = session.client("secretsmanager")
     boto_client.delete_secret(
         SecretId=secret_name,
         ForceDeleteWithoutRecovery=True,

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
@@ -1,5 +1,4 @@
 import logging
-import boto3
 from typing import Any, MutableMapping, Optional
 
 from cloudformation_cli_python_lib import (
@@ -79,7 +78,7 @@ def create_handler(
         secret_name = model.ExternalIDSecretName
     else:
         secret_name = DEFAULT_SECRET_NAME
-    boto_client = session.client("secretsmanager", "us-east-1")
+    boto_client = session.client("secretsmanager")
     boto_client.create_secret(
         Description='The external_id associated with your Datadog AWS Integration.',
         Name=secret_name,
@@ -249,8 +248,6 @@ def read_handler(
     model.HostTags = aws_account.host_tags
     model.FilterTags = aws_account.filter_tags
     model.AccountSpecificNamespaceRules = aws_account.account_specific_namespace_rules
-    if model.ExternalIDSecretName is None:
-        model.secret_name = DEFAULT_SECRET_NAME
 
     return ProgressEvent(
         status=OperationStatus.SUCCESS,

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/models.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/models.py
@@ -47,6 +47,7 @@ class ResourceModel(BaseModel):
     HostTags: Optional[Sequence[str]]
     AccountSpecificNamespaceRules: Optional[MutableMapping[str, bool]]
     IntegrationID: Optional[str]
+    ExternalIDSecretName: Optional[str]
 
     @classmethod
     def _deserialize(
@@ -65,6 +66,7 @@ class ResourceModel(BaseModel):
             HostTags=json_data.get("HostTags"),
             AccountSpecificNamespaceRules=json_data.get("AccountSpecificNamespaceRules"),
             IntegrationID=json_data.get("IntegrationID"),
+            ExternalIDSecretName=json_data.get("ExternalIDSecretName"),
         )
 
 


### PR DESCRIPTION
### What does this PR do?

This fixes the issue of the resource not keeping track of the external_id returned by the Datadog create aws integration api call ([linked issue](https://github.com/DataDog/datadog-cloudformation-resources/issues/71)). This external_id is necessary for creating a linked IAM role to use with the integration.

### Description of the Change

This change creates an AWS SecretsManager secret in the user's AWS account to house the external_id that's returned by the Datadog create API. The resource now also returns the name of this secret (and can take a user defined name for the secret as well).

### Alternate Designs

Not really sure how else we could do this. We need to have access to the external_id in the read handler, and I think in order to do that we need to store it somewhere in the user's aws account. The SecretManager seems like a prime candidate for storing this value.

### Possible Drawbacks

This requires creating an extra resource in the customer's account. I think this is worth it as the customer needs the external_id to finish the integration with datadog.

### Verification Process

I uploaded the modified resource privately and confirmed that the secret is correctly made on create, and deleted on deletion. Choosing the resource name also works as expected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
