### PR TITLE
Set priority on monitor creation/update

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -187,6 +187,10 @@
         "type": "string"
       }
     },
+    "Priority": {
+      "description": "Integer from 1 (high) to 5 (low) indicating alert severity.",
+      "type": "integer" 
+    },
     "Options": {
       "description": "The monitor options",
       "$ref": "#/definitions/MonitorOptions"

--- a/datadog-monitors-monitor-handler/docs/README.md
+++ b/datadog-monitors-monitor-handler/docs/README.md
@@ -15,6 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#message" title="Message">Message</a>" : <i>String</i>,
         "<a href="#name" title="Name">Name</a>" : <i>String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ String, ... ]</i>,
+        "<a href="#priority" title="Priority">Priority</a>" : <i>Integer</i>,
         "<a href="#options" title="Options">Options</a>" : <i><a href="monitoroptions.md">MonitorOptions</a></i>,
         "<a href="#query" title="Query">Query</a>" : <i>String</i>,
         "<a href="#type" title="Type">Type</a>" : <i>String</i>,
@@ -32,6 +33,7 @@ Properties:
     <a href="#name" title="Name">Name</a>: <i>String</i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - String</i>
+    <a href="#priority" title="Priority">Priority</a>: <i>Integer</i>
     <a href="#options" title="Options">Options</a>: <i><a href="monitoroptions.md">MonitorOptions</a></i>
     <a href="#query" title="Query">Query</a>: <i>String</i>
     <a href="#type" title="Type">Type</a>: <i>String</i>
@@ -67,6 +69,16 @@ Tags associated with the monitor
 _Required_: No
 
 _Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Priority
+
+Integer from 1 (high) to 5 (low) indicating alert severity.
+
+_Required_: No
+
+_Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/datadog-monitors-monitor-handler/inputs/inputs_1_create.json
+++ b/datadog-monitors-monitor-handler/inputs/inputs_1_create.json
@@ -3,6 +3,7 @@
   "Query": "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 4",
   "Name": "SSH Activity on PROD",
   "Message": "@slack-datadog-testing",
+  "Priority": 1,
   "Options": {
     "Locked": false,
     "IncludeTags": true,

--- a/datadog-monitors-monitor-handler/inputs/inputs_1_update.json
+++ b/datadog-monitors-monitor-handler/inputs/inputs_1_update.json
@@ -3,6 +3,7 @@
   "Query": "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host} > 5",
   "Name": "SSH Activity on PROD updated",
   "Message": "@slack-datadog-testing",
+  "Priority": 1,
   "Options": {
     "Locked": false,
     "IncludeTags": false,

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
@@ -83,6 +83,7 @@ def read_handler(
     model.Message = monitor.message
     model.Name = monitor.name
     model.Tags = monitor.tags
+    model.Priority = monitor.priority
     model.Query = monitor.query
     model.Multi = monitor.multi
     if monitor.deleted:
@@ -160,6 +161,8 @@ def update_handler(
         monitor.name = model.Name
     if model.Tags is not None:
         monitor.tags = model.Tags
+    if model.Priority is not None:
+        monitor.priority = model.Priority
     options = build_monitor_options_from_model(model)
     if options:
         monitor.options = options
@@ -240,6 +243,8 @@ def create_handler(
         monitor.name = model.Name
     if model.Tags is not None:
         monitor.tags = model.Tags
+    if model.Priority is not None:
+        monitor.priority = model.Priority
     options = build_monitor_options_from_model(model)
     if options:
         monitor.options = options

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
@@ -45,6 +45,7 @@ class ResourceModel(BaseModel):
     Message: Optional[str]
     Name: Optional[str]
     Tags: Optional[Sequence[str]]
+    Priority: Optional[str]
     Options: Optional["_MonitorOptions"]
     Query: Optional[str]
     Type: Optional[str]
@@ -68,6 +69,7 @@ class ResourceModel(BaseModel):
             Message=json_data.get("Message"),
             Name=json_data.get("Name"),
             Tags=json_data.get("Tags"),
+            Priority=json_data.get("Priority"),
             Options=MonitorOptions._deserialize(json_data.get("Options")),
             Query=json_data.get("Query"),
             Type=json_data.get("Type"),


### PR DESCRIPTION
### What does this PR do?

This PR allows a user to specify an alert priority when creating a monitor. [Linked Issue](https://github.com/DataDog/datadog-cloudformation-resources/issues/137)

### Description of the Change

Added the monitor priority to the read, create and update handlers.

### Alternate Designs

### Possible Drawbacks

### Verification Process

### Additional Notes

### Release Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
