### PR TITLE
Use custom exports for AWS contract tests

### DIFF
--- a/datadog-integrations-aws-handler/inputs/inputs_1_create.json
+++ b/datadog-integrations-aws-handler/inputs/inputs_1_create.json
@@ -1,4 +1,4 @@
 {
-  "AccountID": "123456781234",
+  "AccountID": "{{UniqueAWSAccountID}}",
   "RoleName": "testCF"
 }

--- a/datadog-integrations-aws-handler/inputs/inputs_1_update.json
+++ b/datadog-integrations-aws-handler/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "AccountID": "123456781234",
+  "AccountID": "{{UniqueAWSAccountID}}",
   "RoleName": "testCF",
   "FilterTags": ["foo:bar"]
 }


### PR DESCRIPTION
Use  region specific uniquely generated AWS account ids for contract tests