### PR TITLE
Add backward compatibility for TypeConfiguration and ID parsing

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
@@ -1,14 +1,10 @@
 {
-    "typeName": "Datadog::Monitors::Monitor",
-    "description": "Datadog Monitor 3.0.0",
-    "typeConfiguration": {
-        "properties": {
-            "DatadogCredentials": {
-                "$ref": "#/definitions/DatadogCredentials"
-            }
-        },
-        "additionalProperties": false
+    "properties": {
+        "DatadogCredentials": {
+            "$ref": "#/definitions/DatadogCredentials"
+        }
     },
+    "additionalProperties": false,
     "definitions": {
         "Creator": {
             "type": "object",
@@ -158,117 +154,5 @@
             "additionalProperties": false
         }
     },
-    "properties": {
-        "DatadogCredentials": {
-            "$ref": "#/definitions/DatadogCredentials"
-        },
-        "Creator": {
-            "$ref": "#/definitions/Creator"
-        },
-        "Id": {
-            "description": "ID of the monitor",
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-              ]
-        },
-        "Message": {
-            "description": "A message to include with notifications for the monitor",
-            "type": "string"
-        },
-        "Name": {
-            "description": "Name of the monitor",
-            "type": "string"
-        },
-        "Tags": {
-            "description": "Tags associated with the monitor",
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
-        },
-        "Options": {
-            "description": "The monitor options",
-            "$ref": "#/definitions/MonitorOptions"
-        },
-        "Query": {
-            "description": "The monitor query",
-            "type": "string"
-        },
-        "Type": {
-            "type": "string",
-            "description": "The type of the monitor",
-            "enum": [
-                "composite",
-                "event alert",
-                "log alert",
-                "metric alert",
-                "process alert",
-                "query alert",
-                "service check",
-                "synthetics alert",
-                "trace-analytics alert"
-            ]
-        },
-        "Multi": {
-            "description": "Whether or not the monitor is multi alert",
-            "type": "boolean"
-        },
-        "Created": {
-            "description": "Date of creation of the monitor",
-            "type": "string",
-            "format": "date-time"
-        },
-        "Deleted": {
-            "description": "Date of deletion of the monitor",
-            "type": "string",
-            "format": "date-time"
-        },
-        "Modified": {
-            "description": "Date of modification of the monitor",
-            "type": "string",
-            "format": "date-time"
-        }
-    },
-    "required": [
-        "Query",
-        "Type"
-    ],
-    "writeOnlyProperties": [
-        "/properties/DatadogCredentials"
-    ],
-    "primaryIdentifier": [
-        "/properties/Id"
-    ],
-    "readOnlyProperties": [
-        "/properties/Modified",
-        "/properties/Id",
-        "/properties/Deleted",
-        "/properties/State",
-        "/properties/OverallState",
-        "/properties/Creator",
-        "/properties/Created"
-    ],
-    "additionalProperties": false,
-    "handlers": {
-        "create": {
-            "permissions": [""]
-        },
-        "read": {
-            "permissions": [""]
-        },
-        "update": {
-            "permissions": [""]
-        },
-        "delete": {
-            "permissions": [""]
-        },
-        "list": {
-            "permissions": [""]
-        }
-    }
+    "typeName": "Datadog::Monitors::Monitor"
 }

--- a/datadog-monitors-monitor-handler/docs/README.md
+++ b/datadog-monitors-monitor-handler/docs/README.md
@@ -46,7 +46,7 @@ Properties:
 
 Credentials for the Datadog API
 
-_Required_: Yes
+_Required_: No
 
 _Type_: <a href="datadogcredentials.md">DatadogCredentials</a>
 

--- a/datadog-monitors-monitor-handler/requirements.txt
+++ b/datadog-monitors-monitor-handler/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.4#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python
+git+https://github.com/datadog/datadog-cloudformation-resources.git@datadog-cloudformation-common-python-0.0.6#egg=datadog_cloudformation_common&subdirectory=datadog-cloudformation-common-python

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
@@ -35,13 +35,14 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
 class ResourceModel(BaseModel):
     DatadogCredentials: Optional["_DatadogCredentials"]
     Creator: Optional["_Creator"]
-    Id: Optional[int]
+    Id: Optional[Any]
     Message: Optional[str]
     Name: Optional[str]
     Tags: Optional[Sequence[str]]
@@ -229,5 +230,25 @@ class MonitorThresholdWindows(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _MonitorThresholdWindows = MonitorThresholdWindows
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    DatadogCredentials: Optional["_DatadogCredentials"]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls(
+            DatadogCredentials=DatadogCredentials._deserialize(json_data.get("DatadogCredentials")),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel
 
 


### PR DESCRIPTION
This pr:
1) Adds support for configuring api options via both `TypeConfiguration` and using the `DatadogCredentials` property.
2) Allows for parsing `ResourceIdentifierID` from the monitor resource major version v2 which previously stored the ID aas a Long and in scientific format (e.g. 1.23456E5)

The above 2 changes should ease the process for upgrading from v2/v3 -> v4
