### PR TITLE
Copying Stack tags to the Datadog monitor (#226)

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
@@ -2,6 +2,10 @@
     "properties": {
         "DatadogCredentials": {
             "$ref": "#/definitions/DatadogCredentials"
+        },
+        "TagResourceWithStackTags": {
+            "description": "Copy the Cloudformation Stack tags to the datadog monitor. It defaults to false to stay backwards compatible.",
+            "type": "boolean"
         }
     },
     "additionalProperties": false,

--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -5,6 +5,10 @@
     "properties": {
       "DatadogCredentials": {
         "$ref": "#/definitions/DatadogCredentials"
+      },
+      "TagResourceWithStackTags": {
+        "description": "Copy the Cloudformation Stack tags to the datadog monitor. It defaults to false to stay backwards compatible.",
+        "type": "boolean"
       }
     },
     "additionalProperties": false

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
@@ -221,6 +221,7 @@ _MonitorThresholdWindows = MonitorThresholdWindows
 @dataclass
 class TypeConfigurationModel(BaseModel):
     DatadogCredentials: Optional["_DatadogCredentials"]
+    TagResourceWithStackTags: Optional[bool]
 
     @classmethod
     def _deserialize(
@@ -231,6 +232,7 @@ class TypeConfigurationModel(BaseModel):
             return None
         return cls(
             DatadogCredentials=DatadogCredentials._deserialize(json_data.get("DatadogCredentials")),
+            TagResourceWithStackTags=json_data.get("TagResourceWithStackTags"),
         )
 
 


### PR DESCRIPTION
Cloudformation supports tags at a stack level. They are normally passed on to all Cloudformation resources (some resources don't support that yet...). Datadog monitors got tags, too. With this change, the Cloudformation Stack tags are copied to the Datadog monitor. Additionally, the AWS autogenerated tags like stack name and logical id are also set. If a tag is already set explicitly at a monitor, the monitor value is being used. Since Datadog uses a : to separate key and value, all : are replaced with _.

In order to maintain backwards compatibility, this feature is switched off by default. It can be enabled account-wide via the type configuration, the same way Datadog credentials are being set.

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?
This PR fixes https://github.com/DataDog/datadog-cloudformation-resources/issues/226

### Description of the Change

See commit message

### Alternate Designs

No alternate design.

### Possible Drawbacks

There should be none, since the feature is implemented in a backwards-compatible way.

### Verification Process

- created a monitor via cfn with version 4.4.0
- deploy my new version
- updated the monitor text via cfn -> tags showed up
- added to the stack a new monitor -> tags showed up

### Additional Notes
I didn't add a test because there were none and I didn't work with python cloudformation resources before.

### Release Notes
Copying Stack tags to the Datadog monitor (disabled by default)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
