### PR TITLE
Monitors: Pass on Stack tags

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
@@ -87,7 +87,6 @@
                 "IncludeTags": {
                     "description": "Whether or not to include triggering tags into notification title",
                     "type": "boolean",
-                    "insertionOrder": false,
                     "default": true
                 },
                 "Locked": {

--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor-configuration.json
@@ -2,6 +2,10 @@
     "properties": {
         "DatadogCredentials": {
             "$ref": "#/definitions/DatadogCredentials"
+        },
+        "TagResourceWithStackTags": {
+            "description": "Copy the Cloudformation Stack tags to the datadog monitor. It defaults to false to stay backwards compatible.",
+            "type": "boolean"
         }
     },
     "additionalProperties": false,

--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -91,7 +91,6 @@
         "IncludeTags": {
           "description": "Whether or not to include triggering tags into notification title",
           "type": "boolean",
-          "insertionOrder": false,
           "default": true
         },
         "Locked": {
@@ -216,6 +215,7 @@
     "Tags": {
       "description": "Tags associated with the monitor",
       "type": "array",
+      "insertionOrder": false,
       "items": {
         "type": "string"
       }

--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -5,6 +5,10 @@
     "properties": {
       "DatadogCredentials": {
         "$ref": "#/definitions/DatadogCredentials"
+      },
+      "TagResourceWithStackTags": {
+        "description": "Copy the Cloudformation Stack tags to the datadog monitor. It defaults to false to stay backwards compatible.",
+        "type": "boolean"
       }
     },
     "additionalProperties": false

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
@@ -221,6 +221,7 @@ _MonitorThresholdWindows = MonitorThresholdWindows
 @dataclass
 class TypeConfigurationModel(BaseModel):
     DatadogCredentials: Optional["_DatadogCredentials"]
+    TagResourceWithStackTags: Optional[bool]
 
     @classmethod
     def _deserialize(
@@ -231,6 +232,7 @@ class TypeConfigurationModel(BaseModel):
             return None
         return cls(
             DatadogCredentials=DatadogCredentials._deserialize(json_data.get("DatadogCredentials")),
+            TagResourceWithStackTags=json_data.get("TagResourceWithStackTags"),
         )
 
 


### PR DESCRIPTION
This is a follow up to https://github.com/DataDog/datadog-cloudformation-resources/issues/226 to be able to run CI tests.

This PR includes a fix in regards to ignoring tag ordering and ensuring no drift is present on applies.