### PR TITLE
Adds ExcludedRegions Attribute

### DIFF
--- a/datadog-integrations-aws-handler/datadog-integrations-aws.json
+++ b/datadog-integrations-aws-handler/datadog-integrations-aws.json
@@ -95,6 +95,13 @@
     "ResourceCollection": {
       "description": "Enable collecting information on your AWS resources for use in Datadog products such as Network Process Monitoring.",
       "type": "boolean"
+    },
+    "ExcludedRegions": {
+      "description": "Array of AWS regions to exclude from metrics collection.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [],

--- a/datadog-integrations-aws-handler/docs/README.md
+++ b/datadog-integrations-aws-handler/docs/README.md
@@ -147,6 +147,16 @@ _Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### ExcludedRegions
+
+Array of AWS regions to exclude from metrics collection.
+
+_Required_: No
+
+_Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 ## Return Values
 
 ### Ref

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/handlers.py
@@ -51,6 +51,8 @@ def build_aws_account_from_model(model):
         aws_account.cspm_resource_collection_enabled = model.CSPMResourceCollection
     if model.ResourceCollection is not None:
         aws_account.resource_collection_enabled = model.ResourceCollection
+    if model.ExcludedRegions is not None:
+        aws_account.excluded_regions = model.ExcludedRegions
     return aws_account
 
 
@@ -298,6 +300,7 @@ def read_handler(
     model.HostTags = aws_account.host_tags
     model.FilterTags = aws_account.filter_tags
     model.AccountSpecificNamespaceRules = aws_account.account_specific_namespace_rules
+    model.ExcludedRegions = aws_account.excluded_regions
 
     return ProgressEvent(
         status=OperationStatus.SUCCESS,

--- a/datadog-integrations-aws-handler/src/datadog_integrations_aws/models.py
+++ b/datadog-integrations-aws-handler/src/datadog_integrations_aws/models.py
@@ -51,6 +51,7 @@ class ResourceModel(BaseModel):
     MetricsCollection: Optional[bool]
     CSPMResourceCollection: Optional[bool]
     ResourceCollection: Optional[bool]
+    ExcludedRegions: Optional[Sequence[str]]
 
     @classmethod
     def _deserialize(
@@ -73,6 +74,7 @@ class ResourceModel(BaseModel):
             MetricsCollection=json_data.get("MetricsCollection"),
             CSPMResourceCollection=json_data.get("CSPMResourceCollection"),
             ResourceCollection=json_data.get("ResourceCollection"),
+            ExcludedRegions=json_data.get("ExcludedRegions"),
         )
 
 


### PR DESCRIPTION
### What does this PR do?

Adds Support For AWS Account Integration Excluded Regions 

DataDogs AWS Account Integration API has the capability to exclude collecting metrics from given Regions. This exposes access to that API Parameter via the CloudFormation Resource.

### Alternate Designs

None were considered, it follows the established pattern in this repository for integrating the CloudFormation Model with the DataDog API Client.  

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

used `cfn submit` to deploy the custom resource to an AWS Account ExcludedRegion

deployed a version of the CloudFormation without setting Excluded Regions
```yaml
Resources:
  DatadogIntegrationAWS:
    Type: Datadog::Integrations::AWS
    Properties:
      AccountID: !Ref AWS::AccountId
      RoleName: "Test"
```
 
verified in the Datadog UI integration was created 


Deployed version with us-east-1 excluded
```yaml
Resources:
  DatadogIntegrationAWS:
    Type: Datadog::Integrations::AWS
    Properties:
      AccountID: !Ref AWS::AccountId
      RoleName: "Test"
      ExcludedRegions:
        - "us-east-1"
```

verified in Datadog UI that us-east-1 was excluded

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
