### PR TITLE
Remove empty string from permissions

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -528,24 +528,16 @@
   "additionalProperties": false,
   "handlers": {
     "create": {
-      "permissions": [
-        ""
-      ]
+      "permissions": []
     },
     "read": {
-      "permissions": [
-        ""
-      ]
+      "permissions": []
     },
     "update": {
-      "permissions": [
-        ""
-      ]
+      "permissions": []
     },
     "delete": {
-      "permissions": [
-        ""
-      ]
+      "permissions": []
     }
   }
 }


### PR DESCRIPTION
Remove empty permission string as it might now be causing issues with Cloudformation releases. 