### PR TITLE
[Datadog::Dashboards::Dashboard] Add backward compatibility for TypeConfiguration

### DIFF
--- a/datadog-dashboards-dashboard-handler/datadog-dashboards-dashboard.json
+++ b/datadog-dashboards-dashboard-handler/datadog-dashboards-dashboard.json
@@ -1,6 +1,6 @@
 {
   "typeName": "Datadog::Dashboards::Dashboard",
-  "description": "Datadog Dashboard 2.1.0",
+  "description": "Datadog Dashboard 2.1.0 - backward compatible with 1.0.0",
   "typeConfiguration": {
     "properties": {
       "DatadogCredentials": {
@@ -35,6 +35,9 @@
     }
   },
   "properties": {
+    "DatadogCredentials": {
+      "$ref": "#/definitions/DatadogCredentials"
+    },
     "Id": {
       "description": "ID of the dashboard",
       "type": "string"

--- a/datadog-dashboards-dashboard-handler/docs/README.md
+++ b/datadog-dashboards-dashboard-handler/docs/README.md
@@ -1,6 +1,6 @@
 # Datadog::Dashboards::Dashboard
 
-Datadog Dashboard 2.1.0
+Datadog Dashboard 2.1.0 - backward compatible with 1.0.0
 
 ## Syntax
 
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "Datadog::Dashboards::Dashboard",
     "Properties" : {
+        "<a href="#datadogcredentials" title="DatadogCredentials">DatadogCredentials</a>" : <i><a href="datadogcredentials.md">DatadogCredentials</a></i>,
         "<a href="#dashboarddefinition" title="DashboardDefinition">DashboardDefinition</a>" : <i>String</i>
     }
 }
@@ -22,10 +23,21 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: Datadog::Dashboards::Dashboard
 Properties:
+    <a href="#datadogcredentials" title="DatadogCredentials">DatadogCredentials</a>: <i><a href="datadogcredentials.md">DatadogCredentials</a></i>
     <a href="#dashboarddefinition" title="DashboardDefinition">DashboardDefinition</a>: <i>String</i>
 </pre>
 
 ## Properties
+
+#### DatadogCredentials
+
+Credentials for the Datadog API
+
+_Required_: No
+
+_Type_: <a href="datadogcredentials.md">DatadogCredentials</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### DashboardDefinition
 

--- a/datadog-dashboards-dashboard-handler/docs/datadogcredentials.md
+++ b/datadog-dashboards-dashboard-handler/docs/datadogcredentials.md
@@ -1,0 +1,58 @@
+# Datadog::Dashboards::Dashboard DatadogCredentials
+
+Credentials for the Datadog API
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#apikey" title="ApiKey">ApiKey</a>" : <i>String</i>,
+    "<a href="#applicationkey" title="ApplicationKey">ApplicationKey</a>" : <i>String</i>,
+    "<a href="#apiurl" title="ApiURL">ApiURL</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#apikey" title="ApiKey">ApiKey</a>: <i>String</i>
+<a href="#applicationkey" title="ApplicationKey">ApplicationKey</a>: <i>String</i>
+<a href="#apiurl" title="ApiURL">ApiURL</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### ApiKey
+
+Datadog API key
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ApplicationKey
+
+Datadog application key
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ApiURL
+
+Datadog API URL (defaults to https://api.datadoghq.com) Use https://api.datadoghq.eu for EU accounts.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
+++ b/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
@@ -228,14 +228,17 @@ def read_handler(
 
 
 def get_auth(
-        dd_credentials: Optional[DatadogCredentials],
-        type_configuration: Optional[TypeConfigurationModel]
+    dd_credentials: Optional[DatadogCredentials], type_configuration: Optional[TypeConfigurationModel]
 ) -> Tuple[str, str, str]:
     if dd_credentials:
-        return dd_credentials.ApiKey, \
-               dd_credentials.ApplicationKey, \
-               dd_credentials.ApiURL or "https://api.datadoghq.com"
+        return (
+            dd_credentials.ApiKey,
+            dd_credentials.ApplicationKey,
+            dd_credentials.ApiURL or "https://api.datadoghq.com",
+        )
     else:
-        return type_configuration.DatadogCredentials.ApiKey, \
-               type_configuration.DatadogCredentials.ApplicationKey, \
-               type_configuration.DatadogCredentials.ApiURL or "https://api.datadoghq.com"
+        return (
+            type_configuration.DatadogCredentials.ApiKey,
+            type_configuration.DatadogCredentials.ApplicationKey,
+            type_configuration.DatadogCredentials.ApiURL or "https://api.datadoghq.com",
+        )

--- a/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
+++ b/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/handlers.py
@@ -1,7 +1,6 @@
-from ast import Tuple
 import json
 import logging
-from typing import Any, MutableMapping, Optional
+from typing import Any, MutableMapping, Optional, Tuple
 
 from cloudformation_cli_python_lib import (
     Action,
@@ -147,7 +146,6 @@ def delete_handler(
 ) -> ProgressEvent:
     LOG.info("Starting %s Delete Handler", TYPE_NAME)
     model = request.desiredResourceState
-    type_configuration = request.typeConfiguration
 
     dashboard_id = model.Id
 
@@ -188,7 +186,6 @@ def read_handler(
 ) -> ProgressEvent:
     LOG.info("Starting %s Read Handler", TYPE_NAME)
     model = request.desiredResourceState
-    type_configuration = request.typeConfiguration
 
     dashboard_id = model.Id
 

--- a/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/models.py
+++ b/datadog-dashboards-dashboard-handler/src/datadog_dashboards_dashboard/models.py
@@ -41,6 +41,7 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
 
 @dataclass
 class ResourceModel(BaseModel):
+    DatadogCredentials: Optional["_DatadogCredentials"]
     Id: Optional[str]
     Url: Optional[str]
     DashboardDefinition: Optional[str]
@@ -55,6 +56,7 @@ class ResourceModel(BaseModel):
         dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
         recast_object(cls, json_data, dataclasses)
         return cls(
+            DatadogCredentials=DatadogCredentials._deserialize(json_data.get("DatadogCredentials")),
             Id=json_data.get("Id"),
             Url=json_data.get("Url"),
             DashboardDefinition=json_data.get("DashboardDefinition"),
@@ -63,26 +65,6 @@ class ResourceModel(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _ResourceModel = ResourceModel
-
-
-@dataclass
-class TypeConfigurationModel(BaseModel):
-    DatadogCredentials: Optional["_DatadogCredentials"]
-
-    @classmethod
-    def _deserialize(
-        cls: Type["_TypeConfigurationModel"],
-        json_data: Optional[Mapping[str, Any]],
-    ) -> Optional["_TypeConfigurationModel"]:
-        if not json_data:
-            return None
-        return cls(
-            DatadogCredentials=DatadogCredentials._deserialize(json_data.get("DatadogCredentials")),
-        )
-
-
-# work around possible type aliasing issues when variable has same name as a model
-_TypeConfigurationModel = TypeConfigurationModel
 
 
 @dataclass
@@ -107,5 +89,25 @@ class DatadogCredentials(BaseModel):
 
 # work around possible type aliasing issues when variable has same name as a model
 _DatadogCredentials = DatadogCredentials
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    DatadogCredentials: Optional["_DatadogCredentials"]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls(
+            DatadogCredentials=DatadogCredentials._deserialize(json_data.get("DatadogCredentials")),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel
 
 


### PR DESCRIPTION
This pr:

Adds support for configuring api options via both TypeConfiguration and using the DatadogCredentials property.

The above changes will ease the process of upgrading from `1.0.0 -> 2.1.0`

S3 link: s3://datadog-cloudformation-resources/datadog-dashboards-dashboard/datadog-dashboards-dashboard-2.1.0b1.zip

1. Register the above version using the steps outline [here](https://github.com/DataDog/datadog-cloudformation-resources#aws-command-line-interface) and set the newly registered resource version as default. If you would like to manually build and submit the resource using cfn cli, checkout the branch and follow the steps outlined [here](https://github.com/DataDog/datadog-cloudformation-resources/blob/master/DEVELOPMENT.md#testing-the-resource-manually-in-aws)

2. Set the TypeConfiguration for the newly registered resource version. [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-private.html#registry-set-configuration) for setting Type Configuration:
```
{
  "DatadogCredentials": {
      "ApiKey": "{{resolve:secretsmanager:MySecret:SecretString:SecretAPIKey}}",
      "ApplicationKey": "{{resolve:secretsmanager:MySecret:SecretString:SecretAppKey}}"
  }
}
```
3. Remove the DatadogCredentials property from the monitor resource definition.

4. Apply the changes.

You can now upgrade to latest version `2.1.0`.