### PR TITLE
Converting the monitor query to lowercase

### DIFF
--- a/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
+++ b/datadog-monitors-monitor-handler/datadog-monitors-monitor.json
@@ -228,6 +228,10 @@
       "description": "The monitor query",
       "type": "string"
     },
+    "ConvertQueryToLowercase": {
+      "description": "Queries in Datadog are case-sensitive. But tags ingested into datadog are converted to lowercase. If one passes a camel case named AWS resource name into a monitor query, the query will never metch. If you set this to true, it will convert the complete query to lowercase. It defaults to false. NOTE: Enabling this may create drift for your Cloudformation Monitor Resource",
+      "type": "boolean"
+    },
     "Type": {
       "type": "string",
       "description": "The type of the monitor",
@@ -293,6 +297,9 @@
     "/properties/OverallState",
     "/properties/Creator",
     "/properties/Created"
+  ],
+  "writeOnlyProperties": [
+    "/properties/ConvertQueryToLowercase"
   ],
   "additionalProperties": false,
   "handlers": {

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/handlers.py
@@ -160,6 +160,8 @@ def update_handler(
 
     monitor = ApiMonitorUpdateRequest()
     monitor.query = model.Query
+    if model.ConvertQueryToLowercase and model.Query:
+        monitor.query = model.Query.lower()
     monitor.type = ApiMonitorType(model.Type)
     if model.Message is not None:
         monitor.message = model.Message
@@ -242,7 +244,12 @@ def create_handler(
     model = request.desiredResourceState
     type_configuration = request.typeConfiguration
 
-    monitor = ApiMonitor(model.Query, ApiMonitorType(model.Type))
+    if model.ConvertQueryToLowercase and model.Query:
+        query = model.Query.lower()
+    else:
+        query = model.Query
+
+    monitor = ApiMonitor(query, ApiMonitorType(model.Type))
     if model.Message is not None:
         monitor.message = model.Message
     if model.Name is not None:

--- a/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
+++ b/datadog-monitors-monitor-handler/src/datadog_monitors_monitor/models.py
@@ -48,6 +48,7 @@ class ResourceModel(BaseModel):
     Priority: Optional[int]
     Options: Optional["_MonitorOptions"]
     Query: Optional[str]
+    ConvertQueryToLowercase: Optional[bool]
     Type: Optional[str]
     Multi: Optional[bool]
     Created: Optional[str]
@@ -73,6 +74,7 @@ class ResourceModel(BaseModel):
             Priority=json_data.get("Priority"),
             Options=MonitorOptions._deserialize(json_data.get("Options")),
             Query=json_data.get("Query"),
+            ConvertQueryToLowercase=json_data.get("ConvertQueryToLowercase"),
             Type=json_data.get("Type"),
             Multi=json_data.get("Multi"),
             Created=json_data.get("Created"),


### PR DESCRIPTION
Imagine the following situation:

- you are using CDK
- you got a library which generates SQS queues with monitors
- the naming pattern of the queue is ${AWS::StackName}-queue-name
- someone creates a stack name with an upper case character

Now the monitor won't work because:
- the queue name has an uppercase character
- when datadog scrapes the metrics from AWS it converts all to lowercase
- when we create the monitor query and we don't use the lowercase version of teh queue name, the monitor is never going to match
- Cloudformation has no method to convert a string to lowercase

With this change, we can optionally convert the whole query to lowercase, which would fix that.

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
