### PR TITLE
docs: update datadog_checks_dev installation guide

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,7 @@ This project does not have a strict release schedule. However, we would make a r
 
 ### Prerequisite
 
-- Install [datadog_checks_dev](https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.cli.html#installation) using Python 3
+- Install [datadog_checks_dev](https://datadoghq.dev/integrations-core/setup/#ddev) using Python 3
 
 ### Commands
 


### PR DESCRIPTION
### What does this PR do?

- Updates release documentation to include latest link

### Description of the Change

The link provided for installation datadog_checks_dev is now outdated and should instead reference the latest documentation.
