### PR TITLE
bumping datadog api version

### DIFF
--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -29,7 +29,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.9
 install_requires =
-    datadog-api-client==2.17.0
+    datadog-api-client==2.31.0
     cloudformation-cli-python-lib==2.1.17
     cryptography<40.0.0
 setup_requires =

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -29,7 +29,7 @@ package_dir=
 include_package_data = True
 python_requires = >=3.9
 install_requires =
-    datadog-api-client==2.31.0
+    datadog-api-client==2.32.0
     cloudformation-cli-python-lib==2.1.17
     cryptography<40.0.0
 setup_requires =

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -6,7 +6,7 @@ from datadog_api_client import ApiClient, Configuration
 
 @contextmanager
 def client(
-    api_key: str, app_key: str, api_url: str, resource_name: str, resource_version: str, datadog_config: dict = {}
+    api_key: str, app_key: str, api_url: str, resource_name: str, resource_version: str, datadog_config: dict = {}, unstable_operations: dict = {}
 ) -> ApiClient:
     configuration = Configuration(
         host=api_url or "https://api.datadoghq.com",
@@ -16,6 +16,7 @@ def client(
         },
         **datadog_config,
     )
+    configuration.unstable_operations.update(unstable_operations)
 
     with ApiClient(configuration) as api_client:
         try:

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -16,7 +16,8 @@ def client(
         },
         **datadog_config,
     )
-    configuration.unstable_operations.update(unstable_operations)
+    for key, value in unstable_operations.items():
+        configuration.unstable_operations[key] = value
 
     with ApiClient(configuration) as api_client:
         try:


### PR DESCRIPTION
### Requirements for Contributing to this repository

### What does this PR do?
Bumps the Datadog API version. The newest version has the new AWS Integration V2 resources that I want to use. This also adds support for overriding unstable_operations in order to use new apis.

### Description of the Change

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
