### PR TITLE
[TLIBS-120] [MNTS-93317] Add retry support for the common api client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,24 @@ jobs:
     outputs:
       changed_files: ${{ steps.changed_files.outputs.all_changed_files }}
 
+  unit_test_common_python:
+    needs: find_modified_resources
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false && contains(needs.find_modified_resources.outputs.changed_files, 'datadog-cloudformation-common-python')
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Install Python
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+      with:
+        python-version: 3.9
+    - name: Install Deps
+      run: pip install --disable-pip-version-check -e ./datadog-cloudformation-common-python[test]
+    - name: Run Unit Tests
+      run: |
+        cd datadog-cloudformation-common-python
+        pytest tests/ -v
+
   test:
     needs: find_modified_resources
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,22 @@ rpdk.log
 */sam-tests/*
 
 **/*.egg-info/
+
+# Python
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/.pytest_cache/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.coverage
+**/.coverage.*
+**/htmlcov/
+**/coverage.xml
+**/.tox/
+**/.nox/
+**/dist/
+**/*.egg
+.venv/
+.python-version
+.venv/

--- a/datadog-cloudformation-common-python/setup.cfg
+++ b/datadog-cloudformation-common-python/setup.cfg
@@ -43,6 +43,9 @@ where=src
 build =
     cloudformation-cli-python-plugin==2.1.9
     cloudformation-cli==0.2.38
+test =
+    pytest>=7.0
+    pytest-httpserver>=1.0
 
 [flake8]
 max-line-length = 120

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/api_clients.py
@@ -3,6 +3,18 @@ import pkg_resources
 
 from datadog_api_client import ApiClient, Configuration
 
+DEFAULT_API_URL = "https://api.datadoghq.com"
+
+# Defaults for the upstream datadog-api-client retry behavior. Caller-supplied
+# datadog_config overrides any of these. See:
+# https://github.com/DataDog/datadog-api-client-python/blob/2.50.0/src/datadog_api_client/configuration.py
+DEFAULT_RETRY_KWARGS = {
+    "enable_retry": True,
+    "max_retries": 4,
+    "retry_backoff_factor": 2,
+    "request_timeout": (15, 60),
+}
+
 
 @contextmanager
 def client(
@@ -14,14 +26,16 @@ def client(
     datadog_config: dict = {},
     unstable_operations: dict = {},
 ) -> ApiClient:
-    configuration = Configuration(
-        host=api_url or "https://api.datadoghq.com",
-        api_key={
+    config_kwargs = {
+        "host": api_url or DEFAULT_API_URL,
+        "api_key": {
             "apiKeyAuth": api_key,
             "appKeyAuth": app_key,
         },
+        **DEFAULT_RETRY_KWARGS,
         **datadog_config,
-    )
+    }
+    configuration = Configuration(**config_kwargs)
     for key, value in unstable_operations.items():
         configuration.unstable_operations[key] = value
 

--- a/datadog-cloudformation-common-python/tests/conftest.py
+++ b/datadog-cloudformation-common-python/tests/conftest.py
@@ -1,0 +1,18 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2.0 style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2020-Present Datadog, Inc.
+import pytest
+from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture
+def httpserver():
+    server = HTTPServer(host="127.0.0.1", port=0)
+    server.start()
+    try:
+        yield server
+    finally:
+        server.clear()
+        if server.is_running():
+            server.stop()

--- a/datadog-cloudformation-common-python/tests/test_api_clients.py
+++ b/datadog-cloudformation-common-python/tests/test_api_clients.py
@@ -1,0 +1,89 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2.0 style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2020-Present Datadog, Inc.
+from datadog_api_client.rest import RESTClientObject
+from urllib3.util.retry import Retry
+
+from datadog_cloudformation_common.api_clients import DEFAULT_RETRY_KWARGS, client
+
+
+def _make_client(**kwargs):
+    return client(
+        api_key="k",
+        app_key="a",
+        api_url="https://api.datadoghq.com",
+        resource_name="test",
+        resource_version="0",
+        **kwargs,
+    )
+
+
+def test_default_retry_settings_applied():
+    with _make_client() as api_client:
+        cfg = api_client.configuration
+        assert cfg.enable_retry is True
+        assert cfg.max_retries == 4
+        assert cfg.retry_backoff_factor == 2
+        assert cfg.request_timeout == (15, 60)
+
+
+def test_default_kwargs_constants_match():
+    assert DEFAULT_RETRY_KWARGS == {
+        "enable_retry": True,
+        "max_retries": 4,
+        "retry_backoff_factor": 2,
+        "request_timeout": (15, 60),
+    }
+
+
+def test_default_api_url_used_when_none():
+    with client("k", "a", None, "test", "0") as api_client:
+        assert api_client.configuration.host == "https://api.datadoghq.com"
+
+
+def test_caller_can_override_enable_retry_via_datadog_config():
+    with _make_client(datadog_config={"enable_retry": False}) as api_client:
+        assert api_client.configuration.enable_retry is False
+
+
+def test_caller_can_override_max_retries():
+    with _make_client(datadog_config={"max_retries": 7}) as api_client:
+        assert api_client.configuration.max_retries == 7
+
+
+def test_caller_can_override_request_timeout():
+    with _make_client(datadog_config={"request_timeout": (5, 15)}) as api_client:
+        assert api_client.configuration.request_timeout == (5, 15)
+
+
+def test_default_retry_propagates_to_pool_manager():
+    """End-to-end wiring: Configuration -> RESTClientObject -> urllib3 Retry."""
+    with _make_client() as api_client:
+        rest = RESTClientObject(api_client.configuration)
+        retries = rest.pool_manager.connection_pool_kw["retries"]
+        assert isinstance(retries, Retry)
+        assert retries.total == 4
+        assert retries.backoff_factor == 2
+
+
+def test_custom_retry_policy_overrides_built_in():
+    custom = Retry(total=1, backoff_factor=0)
+    with _make_client(datadog_config={"retry_policy": custom}) as api_client:
+        rest = RESTClientObject(api_client.configuration)
+        assert rest.pool_manager.connection_pool_kw["retries"] is custom
+
+
+def test_unstable_operations_still_applied():
+    # _UnstableOperations expects the bare op name (no v1/v2 prefix); the setter
+    # resolves it against the configured op list internally.
+    with _make_client(unstable_operations={"create_incident": True}) as api_client:
+        assert api_client.configuration.unstable_operations["create_incident"] is True
+
+
+def test_user_agent_includes_resource_metadata():
+    with _make_client() as api_client:
+        ua = api_client.user_agent
+        assert "aws-cloudformation-datadog/" in ua
+        assert "resource-name test" in ua
+        assert "resource-version 0" in ua

--- a/datadog-cloudformation-common-python/tests/test_api_clients_behavioral.py
+++ b/datadog-cloudformation-common-python/tests/test_api_clients_behavioral.py
@@ -1,0 +1,162 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2.0 style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2020-Present Datadog, Inc.
+import time
+from unittest.mock import patch
+
+import pytest
+from datadog_api_client.exceptions import ServiceException
+from datadog_api_client.v1.api.authentication_api import AuthenticationApi
+from pytest_httpserver import HTTPServer
+from urllib3.connectionpool import HTTPConnectionPool
+from urllib3.exceptions import ProtocolError, SSLError
+from urllib3.util.retry import Retry
+
+from datadog_cloudformation_common.api_clients import client
+
+# Zero-backoff retry policy used by the HTTP-status tests so they don't sleep.
+# Mirrors enable_retry=True semantics (same status codes, same allowed methods)
+# but skips exponential backoff between attempts. The upstream
+# retry_backoff_factor minimum is 2 which would otherwise force ~6s of sleeps
+# for 3 attempts.
+FAST_RETRY = Retry(
+    total=4,
+    status_forcelist=frozenset({408, 429, 500, 501, 502, 503, 504}),
+    allowed_methods=frozenset({"GET", "PUT", "DELETE", "POST", "PATCH"}),
+    backoff_factor=0,
+    respect_retry_after_header=True,
+)
+
+
+def _client(httpserver: HTTPServer, **datadog_overrides):
+    overrides = {"retry_policy": FAST_RETRY}
+    overrides.update(datadog_overrides)
+    return client(
+        api_key="k",
+        app_key="a",
+        api_url=httpserver.url_for("").rstrip("/"),
+        resource_name="test",
+        resource_version="0",
+        datadog_config=overrides,
+    )
+
+
+def test_retries_on_503_then_succeeds(httpserver: HTTPServer):
+    httpserver.expect_ordered_request("/api/v1/validate").respond_with_data("oops", status=503)
+    httpserver.expect_ordered_request("/api/v1/validate").respond_with_data("oops", status=503)
+    httpserver.expect_ordered_request("/api/v1/validate").respond_with_json(
+        {"valid": True}, status=200
+    )
+
+    with _client(httpserver) as api_client:
+        AuthenticationApi(api_client).validate()
+
+    assert len(httpserver.log) == 3
+
+
+def test_retries_on_429_honors_x_ratelimit_reset(httpserver: HTTPServer):
+    """Datadog's ClientRetry reads X-Ratelimit-Reset (seconds) instead of Retry-After."""
+    httpserver.expect_ordered_request("/api/v1/validate").respond_with_data(
+        "rate limited", status=429, headers={"X-Ratelimit-Reset": "1"}
+    )
+    httpserver.expect_ordered_request("/api/v1/validate").respond_with_json(
+        {"valid": True}, status=200
+    )
+
+    # Use the production retry path so ClientRetry.get_retry_after is exercised.
+    start = time.monotonic()
+    with _client(
+        httpserver,
+        retry_policy=None,
+        enable_retry=True,
+        max_retries=4,
+        retry_backoff_factor=2,
+    ) as api_client:
+        AuthenticationApi(api_client).validate()
+    elapsed = time.monotonic() - start
+
+    assert len(httpserver.log) == 2
+    assert elapsed >= 0.9  # waited ~1s per X-Ratelimit-Reset
+
+
+def test_no_retry_when_disabled(httpserver: HTTPServer):
+    httpserver.expect_request("/api/v1/validate").respond_with_data("oops", status=503)
+
+    with pytest.raises(ServiceException):
+        with _client(httpserver, retry_policy=None, enable_retry=False) as api_client:
+            AuthenticationApi(api_client).validate()
+
+    assert len(httpserver.log) == 1
+
+
+def test_exhausts_retries_then_raises(httpserver: HTTPServer):
+    # 5 attempts (1 initial + 4 retries) all 503 -> request raises
+    for _ in range(5):
+        httpserver.expect_ordered_request("/api/v1/validate").respond_with_data(
+            "oops", status=503
+        )
+
+    with pytest.raises(Exception):
+        with _client(httpserver) as api_client:
+            AuthenticationApi(api_client).validate()
+
+    assert len(httpserver.log) == 5
+
+
+def test_retries_on_ssl_handshake_error(httpserver: HTTPServer):
+    """SSLError raised at the connection layer is retried, then the call recovers."""
+    httpserver.expect_request("/api/v1/validate").respond_with_json({"valid": True})
+
+    original = HTTPConnectionPool._make_request
+    calls = {"n": 0}
+
+    def flaky(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise SSLError("simulated handshake error")
+        return original(self, *args, **kwargs)
+
+    with patch.object(HTTPConnectionPool, "_make_request", flaky):
+        with _client(httpserver) as api_client:
+            AuthenticationApi(api_client).validate()
+
+    assert calls["n"] == 3  # 2 transient SSLErrors + 1 success
+    assert len(httpserver.log) == 1  # only the successful attempt reached the server
+
+
+def test_retries_on_connection_reset(httpserver: HTTPServer):
+    """Mid-flight connection reset (urllib3 ProtocolError) is retried."""
+    httpserver.expect_request("/api/v1/validate").respond_with_json({"valid": True})
+
+    original = HTTPConnectionPool._make_request
+    calls = {"n": 0}
+
+    def flaky(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ProtocolError("Connection broken: ConnectionResetError")
+        return original(self, *args, **kwargs)
+
+    with patch.object(HTTPConnectionPool, "_make_request", flaky):
+        with _client(httpserver) as api_client:
+            AuthenticationApi(api_client).validate()
+
+    assert calls["n"] == 2
+
+
+def test_persistent_ssl_error_eventually_raises(httpserver: HTTPServer):
+    """When SSLError persists, all retries are exhausted and the wrapped error propagates."""
+    calls = {"n": 0}
+
+    def always_fail(self, *args, **kwargs):
+        calls["n"] += 1
+        raise SSLError("persistent handshake error")
+
+    with patch.object(HTTPConnectionPool, "_make_request", always_fail):
+        with pytest.raises(Exception):
+            with _client(httpserver) as api_client:
+                AuthenticationApi(api_client).validate()
+
+    # 1 initial + 4 retries = 5 total attempts (max_retries=4 in our FAST_RETRY)
+    assert calls["n"] == 5


### PR DESCRIPTION
## Add retry support to `datadog-cloudformation-common-python`

  ### Summary

  - Enable automatic HTTP retries by default in the `api_clients.client()` context manager, using the built-in retry support from `datadog-api-client-python`.
  - Default retry policy: `enable_retry=True`, `max_retries=4`, `retry_backoff_factor=2`, `request_timeout=(15, 60)`. Callers can override any of these via `datadog_config`.
  - Add a `unit_test_common_python` CI job that runs pytest against `datadog-cloudformation-common-python` when files in that directory change.

  ### Changes

  - **`api_clients.py`**: Inject `DEFAULT_RETRY_KWARGS` into the `Configuration` constructor; callers can still override individual fields (or the entire `retry_policy`) via `datadog_config`.
  - **`setup.cfg`**: Add a `test` extras group (`pytest`, `pytest-httpserver`) for the new test suite.
  - **`tests/`**: New unit and behavioral test files covering default retry settings, per-field overrides, urllib3 wiring, 5xx/429/SSL/connection-reset retry scenarios, and retry exhaustion.
  - **`.gitignore`**: Add Python build/cache artifact patterns.
  - **`.github/workflows/test.yml`**: Add `unit_test_common_python` job.