### PR TITLE
[TLIBS-120] [MNTS-93317] Prepare for common package `0.0.23` release

### DIFF
--- a/datadog-cloudformation-common-python/CHANGELOG.md
+++ b/datadog-cloudformation-common-python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## datadog-cloudformation-common-python-0.0.23 / 2026-06-11
+
+* [Added] Add retry support in the common api client. See [341](https://github.com/DataDog/datadog-cloudformation-resources/pull/341)
+
 ## datadog-cloudformation-common-python-0.0.22 / 2026-01-27
 
 * [Added] Bump datadog-api-client to 2.50.0.

--- a/datadog-cloudformation-common-python/src/datadog_cloudformation_common/version.py
+++ b/datadog-cloudformation-common-python/src/datadog_cloudformation_common/version.py
@@ -2,4 +2,4 @@
 # under the Apache 2.0 style license (see LICENSE).
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2020-Present Datadog, Inc.
-__version__ = "0.0.22"
+__version__ = "0.0.23"


### PR DESCRIPTION
* [Added] Add retry support in the common api client. See [341](https://github.com/DataDog/datadog-cloudformation-resources/pull/341)
